### PR TITLE
Update air repository reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ During development, it can help massive to have hot reload to be able to make ch
 Air is a great tool to auto reload potentially any project, but works great with Go. Install with:
 
 ```bash
-go install github.com/cosmtrek/air@latest
+go install github.com/air-verse/air@latest
 ```
 
 The `.toml` is already configured and ready in this repository, so simply run:


### PR DESCRIPTION
It looks like Air has changed its repository. Using the old one throws an error while installing the binary.