### PR TITLE
adding css line wrap changes

### DIFF
--- a/assets/styles/invoice.css
+++ b/assets/styles/invoice.css
@@ -366,6 +366,11 @@ section.payment .due-dates span.percent:before {
 section.payment .due-dates span.percent:after {
     content: ")";
 }
+section.payment .due-dates td.date,
+section.payment .due-dates td.amount {
+    width: fit-content;
+    white-space: nowrap;
+}
 section.payment {
     border-bottom: 0.5px solid #e5e7eb;
     padding: 6mm 0mm;


### PR DESCRIPTION
https://app.usepylon.com/issues/views/all-issues?conversationID=7f6ab2d0-e390-4dac-a440-f5bef7bd0671&view=fs

When there's long payment instructions and also due dates, the lack of space makes the "date" and "amount" cells to wrap. In general, dates and amounts should never wrap.