### PR TITLE
Changing translations

### DIFF
--- a/components/bill/payment_details.templ
+++ b/components/bill/payment_details.templ
@@ -166,7 +166,7 @@ templ paymentTerms(terms *pay.Terms) {
 			if len(terms.DueDates) > 0 {
 				<li class="due-dates">
 					<span class="label">
-						@t.T(".due_dates")
+						@t.N(".due_dates", len(terms.DueDates))
 					</span>
 					<span class="value">
 						@paymentDueDates(terms)

--- a/locales/de/app.yml
+++ b/locales/de/app.yml
@@ -43,6 +43,7 @@ de:
         discount: "Rabatt"
         charges: "Gebühren"
         total: "Gesamt"
+        no_percent: "—"
         exemption: "Befreiung"
 
       totals: &totals
@@ -71,6 +72,7 @@ de:
         rate: "Satz"
         amount: "Betrag"
         exemption: "Befreiung"
+        no_percent: "—"
 
       payment: &payment
         title: "Zahlung"
@@ -96,7 +98,9 @@ de:
         terms:
           key: "Zahlungsbedingungen"
           notes: "Zahlungsbedingungen Hinweise"
-          due_dates: "Fälligkeitsdatum"
+          due_dates: 
+            one: "Fälligkeitsdatum"
+            other: "Fälligkeitsdaten"
           keys:
             na: "Nicht angegeben"
             end_of_month: "Ende des Monats"

--- a/locales/el/app.yml
+++ b/locales/el/app.yml
@@ -45,6 +45,7 @@ el:
         discount: "Έκπτωση"
         charges: "Χρεώσεις"
         total: "Σύνολο"
+        no_percent: "—"
         exemption: "Απαλλαγή"
 
       totals: &totals
@@ -73,6 +74,7 @@ el:
         rate: "Ποσοστό"
         amount: "Ποσό"
         exemption: "Απαλλαγή"
+        no_percent: "—"
 
       payment: &payment
         title: "Πληρωμή"
@@ -97,7 +99,9 @@ el:
         terms:
           key: "Όροι πληρωμής"
           notes: "Σημειώσεις όρων πληρωμής"
-          due_dates: "Ημερομηνίες πληρωμής"
+          due_dates:
+            one: "Ημερομηνία πληρωμής"
+            many: "Ημερομηνίες πληρωμής"
           keys:
             na: "Δεν έχει καθοριστεί"
             end_of_month: "Τέλος μήνα"

--- a/locales/en/app.yml
+++ b/locales/en/app.yml
@@ -102,7 +102,9 @@ en:
         terms:
           key: "Payment terms"
           notes: "Payment terms notes"
-          due_dates: "Due dates"
+          due_dates:
+            one: "Due date"
+            other: "Due dates"
           keys:
             na: "Not specified"
             end_of_month: "End of month"

--- a/locales/es/app.yml
+++ b/locales/es/app.yml
@@ -46,6 +46,7 @@ es:
         discount: "Desc."
         charges: "Cargos"
         total: "Total"
+        no_percent: "—"
         exemption: "Exención"
 
       totals: &totals
@@ -70,10 +71,11 @@ es:
       taxes:
         title: "Impuestos"
         category: "Impuesto"
-        base: "Base"
+        base: "Base imponible"
         rate: "Tasa"
         amount: "Monto"
         exemption: "Exención"
+        no_percent: "—"
 
       payment: &payment
         title: "Pago"
@@ -99,7 +101,9 @@ es:
         terms:
           key: "Términos de pago"
           notes: "Notas de términos de pago"
-          due_dates: "Fechas de vencimiento"
+          due_dates: 
+            one: "Fecha de vencimiento"
+            many: "Fechas de vencimiento"
           keys:
             na: "No especificado"
             end_of_month: "Fin de mes"

--- a/locales/fr/app.yml
+++ b/locales/fr/app.yml
@@ -38,6 +38,7 @@ fr:
         discount: "Remise"
         charges: "Frais"
         total: "Total"
+        no_percent: "—"
         exemption: "Exonération"
       totals: &totals
         sum: "Somme"
@@ -64,6 +65,7 @@ fr:
         rate: "Taux"
         amount: "Montant"
         exemption: "Exonération"
+        no_percent: "—"
       payment: &payment
         title: "Paiement"
         instructions: &payment_instructions
@@ -88,7 +90,9 @@ fr:
         terms:
           key: "Conditions de paiement"
           notes: "Notes sur les conditions de paiement"
-          due_dates: "Dates d'échéance"
+          due_dates: 
+            one: "Date d'échéance"
+            many: "Dates d'échéance"
           keys:
             na: "Non spécifié"
             end-of-month: "Fin du mois"

--- a/locales/it/app.yml
+++ b/locales/it/app.yml
@@ -38,13 +38,14 @@ it:
         discount: "Sconto"
         charges: "Oneri"
         total: "Totale"
+        no_percent: "—"
         exemption: "Esenzione"
       totals: &totals
         sum: "Somma"
         discount: "Sconto"
         charge: "Oneri"
         title: "Totali"
-        prices_include: "%{tax} incluse"
+        prices_include: "%{tax} inclusa"
         total: "Totale"
         taxes: "Tasse"
         total_with_tax: "Totale con tasse"
@@ -60,10 +61,11 @@ it:
       taxes:
         title: "Tasse"
         category: "Tassa"
-        base: "Base"
+        base: "Base imponibile"
         rate: "Aliquota"
         amount: "Importo"
         exemption: "Esenzione"
+        no_percent: "—"
       payment: &payment
         title: "Pagamento"
         instructions: &payment_instructions
@@ -87,7 +89,9 @@ it:
         terms:
           key: "Termini di pagamento"
           notes: "Note sui termini di pagamento"
-          due_dates: "Scadenze"
+          due_dates:
+            one: "Scadenza"
+            other: "Scadenze"
           keys:
             na: "Non specificato"
             end_of_month: "Fine mese"

--- a/locales/pl/app.yml
+++ b/locales/pl/app.yml
@@ -43,6 +43,7 @@ pl:
         discount: "Rabat"
         charges: "Opłaty"
         total: "Suma"
+        no_percent: "—"
         exemption: "Zwolnienie"
 
       totals: &totals
@@ -71,6 +72,7 @@ pl:
         rate: "Stawka"
         amount: "Kwota"
         exemption: "Zwolnienie"
+        no_percent: "—"
 
       payment: &payment
         title: "Płatność"
@@ -95,7 +97,9 @@ pl:
         terms:
           key: "Warunki płatności"
           notes: "Uwagi dotyczące warunków płatności"
-          due_dates: "Terminy płatności"
+          due_dates: 
+            one: "Termin płatności"
+            many: "Terminy płatności"
           keys:
             na: "Nieokreślone"
             end_of_month: "Koniec miesiąca"

--- a/locales/pt/app.yml
+++ b/locales/pt/app.yml
@@ -97,7 +97,9 @@ pt:
         terms:
           key: "Condições de Pagamento"
           notes: "Notas das Condições de Pagamento"
-          due_dates: "Datas de vencimento"
+          due_dates: 
+            one: "Data de vencimento"
+            many: "Datas de vencimento"
           keys:
             na: "Não especificado"
             end_of_month: "Fim do mês"


### PR DESCRIPTION
This PR pluralizes "due_dates" as it's an array, it's usually only one date (singular) and our default translation was plural  ("due dates").

It also changes "Base" to "Base imponibile" in `it` and "Base imponible" in `es`, and adds translations for "no_percent" which were missing in languages other than `pt` or `es` yet it's needed in other regimes.

Related issue 
https://app.usepylon.com/issues?conversationID=e60d9a55-e693-4653-adf1-f55b43c4edca