### PR TITLE
VERI*FACTU's op-class should take precedence over regime

### DIFF
--- a/components/bill/taxes.templ
+++ b/components/bill/taxes.templ
@@ -135,6 +135,13 @@ func taxExemptionCode(percent *num.Percentage, ext tax.Extensions) string {
 		}
 	}
 
+	// Next try a code with the word `class` in the key
+	for k, v := range ext {
+		if strings.Contains(k.String(), "class") {
+			return fmt.Sprintf("(%s)", v.String())
+		}
+	}
+
 	// Next return the first code found
 	for _, v := range ext {
 		return fmt.Sprintf("(%s)", v.String())

--- a/components/bill/taxes_templ.go
+++ b/components/bill/taxes_templ.go
@@ -347,6 +347,13 @@ func taxExemptionCode(percent *num.Percentage, ext tax.Extensions) string {
 		}
 	}
 
+	// Next try a code with the word `class` in the key
+	for k, v := range ext {
+		if strings.Contains(k.String(), "class") {
+			return fmt.Sprintf("(%s)", v.String())
+		}
+	}
+
 	// Next return the first code found
 	for _, v := range ext {
 		return fmt.Sprintf("(%s)", v.String())


### PR DESCRIPTION
Assuming a structure like this:

```
                        "rates": [
                            {
                                "key": "reverse-charge",
                                "ext": {
                                    "es-verifactu-regime": "01",
                                    "es-verifactu-op-class": "S2"
                                },
                                "base": "10.00",
                                "amount": "0.00"
                            }
                        ],
                        
```

[… pdf](https://assets.usepylon.com/dd226bc1-3c44-418b-be59-672d8ba50987%2Ff1030d3c-bfe4-4cd2-918c-c6fe24cf4c73-Screenshot2025-12-03at09.22.42.png?Expires=253370764800&Signature=WBYzjstyHd15Y9ZTk7ZbIeFsqb~sivMZ~dxAaNm4KeOsGr-HTHMRVQE5sO6GljTSpJr18~O0TU43Op2o6r9KQcBrm5NeCy4yT~KLHR-4B7lmrWxQQcpU~RrCR44qbmQc90sjNFLyYuD57nO45paUuKGzoSrF-bfbZg9j0AeqqDJ1H14VsL7pKXil1LGf8HPuj9K4ttj0cAymUiLpWHz7dxehBwL4p5YZ1MDnS0aIIXKCLzW5wL2~6OqPHICmNz92C~Graa9Wu1Xm24ftg3dsYQqUWZkwb-qz49DID5NwCISafk1nV1WwbC2qyjHUjcyr92MIYxzljA8N3t0xizsTpw__&Key-Pair-Id=K3NV4LZ47N8M46)

Our PDF will render "01" as the exemption reason (in reality it's random but placing it first makes it more likely to happen).

We need to give priority to `es-verifactu-op-class`.

Related support ticket:
https://app.usepylon.com/issues?conversationID=a8e085b4-0c4c-4c7c-94be-aee339a6ff63