### PR TITLE
Add CUIT label for Argentine tax IDs

### DIFF
--- a/components/org/party.templ
+++ b/components/org/party.templ
@@ -227,6 +227,8 @@ func showTaxID(party *org.Party) bool {
 func taxIDLabel(ctx context.Context, party *org.Party) string {
 	tID := party.TaxID
 	switch tID.Country {
+	case "AR":
+		return "CUIT"
 	case "ES":
 		return "NIF"
 	case "CO":

--- a/components/org/party_templ.go
+++ b/components/org/party_templ.go
@@ -781,6 +781,8 @@ func showTaxID(party *org.Party) bool {
 func taxIDLabel(ctx context.Context, party *org.Party) string {
 	tID := party.TaxID
 	switch tID.Country {
+	case "AR":
+		return "CUIT"
 	case "ES":
 		return "NIF"
 	case "CO":

--- a/examples/out/ar-arca-invoice-logo.html
+++ b/examples/out/ar-arca-invoice-logo.html
@@ -107,7 +107,7 @@
                     Email: ventas@proveedorejemplo.com.ar
                   </div>
                   <div class="tax-id">
-                    TIN: (AR) 30712345671
+                    CUIT: (AR) 30712345671
                   </div>
                   <div class="registration">
                     <span>
@@ -141,7 +141,7 @@
                     Email: compras@clientecomercial.com.ar
                   </div>
                   <div class="tax-id">
-                    TIN: (AR) 30987654321
+                    CUIT: (AR) 30987654321
                   </div>
                   <div class="arca-vat-legend">
                     IVA RESPONSABLE INSCRIPTO

--- a/examples/out/ar-arca-invoice.html
+++ b/examples/out/ar-arca-invoice.html
@@ -107,7 +107,7 @@
                     Email: ventas@proveedorejemplo.com.ar
                   </div>
                   <div class="tax-id">
-                    TIN: (AR) 30712345671
+                    CUIT: (AR) 30712345671
                   </div>
                   <div class="registration">
                     <span>
@@ -141,7 +141,7 @@
                     Email: compras@clientecomercial.com.ar
                   </div>
                   <div class="tax-id">
-                    TIN: (AR) 30987654321
+                    CUIT: (AR) 30987654321
                   </div>
                   <div class="arca-vat-legend">
                     IVA RESPONSABLE INSCRIPTO

--- a/examples/out/ar-arca-liquido-producto.html
+++ b/examples/out/ar-arca-liquido-producto.html
@@ -107,7 +107,7 @@
                     Email: ventas@proveedorejemplo.com.ar
                   </div>
                   <div class="tax-id">
-                    TIN: (AR) 30712345671
+                    CUIT: (AR) 30712345671
                   </div>
                   <div class="registration">
                     <span>
@@ -141,7 +141,7 @@
                     Email: compras@clientecomercial.com.ar
                   </div>
                   <div class="tax-id">
-                    TIN: (AR) 30987654321
+                    CUIT: (AR) 30987654321
                   </div>
                   <div class="arca-vat-legend">
                     IVA RESPONSABLE INSCRIPTO


### PR DESCRIPTION
Fixes APP-471

## Summary
- Argentine parties were rendering with the generic "TIN" fallback in `taxIDLabel`. Added an `AR` case so they display **CUIT**, matching local convention.
- Regenerated `party_templ.go` via `templ generate` and updated the three `ar-arca-*` example snapshots accordingly.

Note: the linked Linear issue also mentions IIBB and a missing state — this PR only addresses the CUIT label. Those remain to be tackled.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Spot-check rendered Argentine invoice in the gallery / browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)