### PR TITLE
Configure date and time formatting independently

### DIFF
--- a/cmd/gobl.html/serve.go
+++ b/cmd/gobl.html/serve.go
@@ -124,8 +124,8 @@ func (s *serveOpts) render(c echo.Context, req *options, env *gobl.Envelope, opt
 	var err error
 
 	// Prepare the request options
-	if req.DateFormat != "" {
-		opts = append(opts, goblhtml.WithCalFormatter(req.DateFormat, "", time.UTC))
+	if req.DateFormat != "" || req.TimeFormat != "" {
+		opts = append(opts, goblhtml.WithCalFormatter(req.DateFormat, req.TimeFormat, time.UTC))
 	}
 	opts = append(opts, goblhtml.WithLocale(req.Locale))
 
@@ -176,6 +176,7 @@ type options struct {
 	Filename       string      `param:"filename"`
 	Locale         i18n.Code   `query:"locale"`
 	DateFormat     string      `query:"date_format"`
+	TimeFormat     string      `query:"time_format"`
 	LogoURL        string      `query:"logo_url"`
 	LogoHeight     int32       `query:"logo_height"`
 	Notes          string      `query:"notes"`

--- a/components/t/i18n.templ
+++ b/components/t/i18n.templ
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/invopop/ctxi18n/i18n"
+	"github.com/invopop/gobl.html/internal"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
@@ -69,7 +70,8 @@ func Localize(ctx context.Context, a any) string {
 		return nf.Percentage(v)
 	case cal.DateTime:
 		cf := calFormatter(ctx)
-		return v.In(cf.Location).Format(cf.DateTime)
+		t := v.In(cf.Location)
+		return t.Format(cf.Date) + internal.DateTimeSeparator + t.Format(cf.Time)
 	case cal.Date:
 		cf := calFormatter(ctx)
 		return v.Time().Format(cf.Date)

--- a/components/t/i18n_templ.go
+++ b/components/t/i18n_templ.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 
 	"github.com/invopop/ctxi18n/i18n"
+	"github.com/invopop/gobl.html/internal"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
@@ -44,7 +45,7 @@ func T(key string, args ...any) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, key, args...))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/t/i18n.templ`, Line: 16, Col: 28}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/t/i18n.templ`, Line: 17, Col: 28}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -79,7 +80,7 @@ func N(key string, n int, args ...any) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.N(ctx, key, n, args...))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/t/i18n.templ`, Line: 21, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/t/i18n.templ`, Line: 22, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -115,7 +116,7 @@ func L(a any) templ.Component {
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(Localize(ctx, a))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/t/i18n.templ`, Line: 27, Col: 19}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/t/i18n.templ`, Line: 28, Col: 19}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
@@ -150,7 +151,7 @@ func LM(a num.Amount) templ.Component {
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(LocalizeMoney(ctx, a))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/t/i18n.templ`, Line: 32, Col: 24}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/t/i18n.templ`, Line: 33, Col: 24}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
@@ -186,7 +187,7 @@ func LC(a num.Amount, cur currency.Code) templ.Component {
 		var templ_7745c5c3_Var10 string
 		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(LocalizeCurrency(ctx, a, cur))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/t/i18n.templ`, Line: 38, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/t/i18n.templ`, Line: 39, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
@@ -222,7 +223,7 @@ func LCD(a num.Amount, cur currency.Code) templ.Component {
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(LocalizeCurrency(ctx, a, cur, currency.WithDisambiguateSymbol()))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/t/i18n.templ`, Line: 44, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/t/i18n.templ`, Line: 45, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
@@ -282,7 +283,8 @@ func Localize(ctx context.Context, a any) string {
 		return nf.Percentage(v)
 	case cal.DateTime:
 		cf := calFormatter(ctx)
-		return v.In(cf.Location).Format(cf.DateTime)
+		t := v.In(cf.Location)
+		return t.Format(cf.Date) + internal.DateTimeSeparator + t.Format(cf.Time)
 	case cal.Date:
 		cf := calFormatter(ctx)
 		return v.Time().Format(cf.Date)

--- a/components/t/i18n_test.go
+++ b/components/t/i18n_test.go
@@ -1,0 +1,73 @@
+package t_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	calT "github.com/invopop/gobl.html/components/t"
+	"github.com/invopop/gobl.html/internal"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/num"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLocalizeDateTime(t *testing.T) {
+	// 2026-03-25T12:34 – matches the co-dian-invoice example that has both
+	// issue_date and issue_time, which is the scenario fixed by APP-472.
+	dt := cal.MakeDateTime(2026, time.March, 25, 12, 34, 0)
+
+	nf := num.Formatter{}
+	tests := []struct {
+		name     string
+		date     string
+		timeF    string
+		expected string
+	}{
+		{
+			name:     "ISO defaults",
+			date:     "",
+			timeF:    "",
+			expected: "2026-03-25 · 12:34",
+		},
+		{
+			name:     "custom date format keeps date_format when issue_time present",
+			date:     "02/01/2006",
+			timeF:    "",
+			expected: "25/03/2026 · 12:34",
+		},
+		{
+			name:     "custom date and time format",
+			date:     "02/01/2006",
+			timeF:    "3:04 PM",
+			expected: "25/03/2026 · 12:34 PM",
+		},
+		{
+			name:     "default date with custom time format",
+			date:     "",
+			timeF:    "3:04 PM",
+			expected: "2026-03-25 · 12:34 PM",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cf := internal.CalFormatterISO
+			if tc.date != "" {
+				cf.Date = tc.date
+			}
+			if tc.timeF != "" {
+				cf.Time = tc.timeF
+			}
+
+			opts := &internal.Opts{
+				CalFormatter: &cf,
+				NumFormatter: &nf,
+			}
+			ctx := internal.WithOptions(context.Background(), opts)
+
+			got := calT.Localize(ctx, dt)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/goblhtml.go
+++ b/goblhtml.go
@@ -62,15 +62,18 @@ func WithLocale(locale i18n.Code) Option {
 	}
 }
 
-// WithCalFormatter prepares simple date and datetime formatting.
-func WithCalFormatter(date, dateTime string, loc *time.Location) Option {
+// WithCalFormatter prepares simple date and time formatting. The date and
+// time formats are configured independently; date-time values render as
+// "<date><sep><time>" using the provided formats. Pass an empty string to
+// keep the ISO default for a given field.
+func WithCalFormatter(date, t string, loc *time.Location) Option {
 	return func(o *internal.Opts) {
 		cf := internal.CalFormatterISO
 		if date != "" {
 			cf.Date = date
 		}
-		if dateTime != "" {
-			cf.DateTime = dateTime
+		if t != "" {
+			cf.Time = t
 		}
 		if loc != nil {
 			cf.Location = loc

--- a/goblhtml.go
+++ b/goblhtml.go
@@ -66,14 +66,14 @@ func WithLocale(locale i18n.Code) Option {
 // time formats are configured independently; date-time values render as
 // "<date><sep><time>" using the provided formats. Pass an empty string to
 // keep the ISO default for a given field.
-func WithCalFormatter(date, t string, loc *time.Location) Option {
+func WithCalFormatter(date, timeFormat string, loc *time.Location) Option {
 	return func(o *internal.Opts) {
 		cf := internal.CalFormatterISO
 		if date != "" {
 			cf.Date = date
 		}
-		if t != "" {
-			cf.Time = t
+		if timeFormat != "" {
+			cf.Time = timeFormat
 		}
 		if loc != nil {
 			cf.Location = loc

--- a/internal/options.go
+++ b/internal/options.go
@@ -77,17 +77,23 @@ func Options(ctx context.Context) *Opts {
 	return nil
 }
 
-// CalFormatter defines a simple date and datetime formatter
+// CalFormatter defines a simple date and time formatter. Date and time
+// formats are configured independently; date-time values are rendered by
+// composing the two with a separator.
 type CalFormatter struct {
 	Date     string // Golang date format for dates, e.g. `02/01/2006`
+	Time     string // Golang time format for times, e.g. `15:04`
 	Location *time.Location
-	DateTime string // Date-time format
 }
 
 // CalFormatterISO is the default formatter for dates and times based on
 // the recommended ISO 8601 formatting.
 var CalFormatterISO = CalFormatter{
 	Date:     "2006-01-02",
-	DateTime: "2006-01-02 · 15:04",
+	Time:     "15:04",
 	Location: time.UTC,
 }
+
+// DateTimeSeparator is used to join the formatted date and time when
+// rendering a cal.DateTime value.
+const DateTimeSeparator = " · "


### PR DESCRIPTION
Fixes APP-472

## Summary
- Replaces `CalFormatter.DateTime` with a `Time` field. `cal.DateTime` rendering now composes `<date format> · <time format>`, so a user-supplied `date_format` always applies — even when the document has an issue time.
- Adds a `time_format` query parameter to the CLI server, configured independently from `date_format`.

## Public API change
The second parameter of `goblhtml.WithCalFormatter(date, time, loc)` is now a **time-only** template (e.g. `15:04`, `3:04 PM`) instead of a combined date-time template (e.g. `2006-01-02 · 15:04`). The only in-repo caller (`cmd/gobl.html`) passed `""`, so it is unaffected. External callers (notably `pdf.go`) will need to pass a time format instead of a combined template.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (defaults still produce identical output: `2026-03-25 · 12:34`)
- [x] Manual render with `WithCalFormatter("02/01/2006", "", time.UTC)` on `co-dian-invoice.json` (has `issue_date` + `issue_time`) now outputs `25/03/2026 · 12:34` — bug fixed
- [x] Manual render with `WithCalFormatter("02/01/2006", "3:04 PM", time.UTC)` outputs `25/03/2026 · 12:34 PM` — independent time format confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)