### PR TITLE
Add Argentina type T invoice pdf support

### DIFF
--- a/components/bill/totals.templ
+++ b/components/bill/totals.templ
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/invopop/ctxi18n/i18n"
+	"github.com/invopop/gobl.html/components/regimes/ar"
 	"github.com/invopop/gobl.html/components/t"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/currency"
@@ -119,6 +120,8 @@ templ totalsPayableRows(inv *bill.Invoice, totals *bill.Totals) {
 			</td>
 		</tr>
 	}
+	@ar.ARCATourismRefund(inv)
+	{{ payable := ar.TourismPayable(inv, totals.Payable) }}
 	<tr class="payable strong">
 		<th>
 			if inv.Type.In(bill.InvoiceTypeCreditNote) {
@@ -130,7 +133,7 @@ templ totalsPayableRows(inv *bill.Invoice, totals *bill.Totals) {
 			}
 		</th>
 		<td>
-			@t.LM(totals.Payable)
+			@t.LM(payable)
 		</td>
 	</tr>
 	for _, er := range totalExchangeRates(inv) {
@@ -139,7 +142,7 @@ templ totalsPayableRows(inv *bill.Invoice, totals *bill.Totals) {
 				@t.T(".exchange_rate", i18n.M{"to": er.To, "amount": t.Localize(ctx, er.Amount)})
 			</th>
 			<td>
-				@t.LCD(er.Convert(totals.Payable), er.To)
+				@t.LCD(er.Convert(payable), er.To)
 			</td>
 		</tr>
 	}

--- a/components/bill/totals_templ.go
+++ b/components/bill/totals_templ.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/invopop/ctxi18n/i18n"
+	"github.com/invopop/gobl.html/components/regimes/ar"
 	"github.com/invopop/gobl.html/components/t"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/currency"
@@ -339,6 +340,11 @@ func totalsPayableRows(inv *bill.Invoice, totals *bill.Totals) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
+		templ_7745c5c3_Err = ar.ARCATourismRefund(inv).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		payable := ar.TourismPayable(inv, totals.Payable)
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<tr class=\"payable strong\"><th>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -362,7 +368,7 @@ func totalsPayableRows(inv *bill.Invoice, totals *bill.Totals) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = t.LM(totals.Payable).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = t.LM(payable).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -383,7 +389,7 @@ func totalsPayableRows(inv *bill.Invoice, totals *bill.Totals) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = t.LCD(er.Convert(totals.Payable), er.To).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = t.LCD(er.Convert(payable), er.To).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/components/regimes/ar/ar.go
+++ b/components/regimes/ar/ar.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/invopop/gobl.html/internal"
 	"github.com/invopop/gobl/addons/ar/arca"
+	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
 )
 
 // vatStatusLegends maps ar-arca-vat-status codes to their official legend text
@@ -43,13 +46,14 @@ func arcaVATLegend(doc internal.Document, party *org.Party, role string) string 
 	if role == "supplier" {
 		return supplierLegend(doc, cbc.Code(dt.String()))
 	}
-	return customerLegend(party)
+	return customerLegend(party, cbc.Code(dt.String()))
 }
 
 func supplierLegend(_ internal.Document, docType cbc.Code) string {
 	switch {
 	case slices.Contains(arca.DocTypesA, docType),
-		slices.Contains(arca.DocTypesB, docType):
+		slices.Contains(arca.DocTypesB, docType),
+		slices.Contains(arca.DocTypesT, docType):
 		return "IVA RESPONSABLE INSCRIPTO"
 	case slices.Contains(arca.DocTypesC, docType):
 		return "RESPONSABLE MONOTRIBUTO"
@@ -57,7 +61,35 @@ func supplierLegend(_ internal.Document, docType cbc.Code) string {
 	return ""
 }
 
-func customerLegend(party *org.Party) string {
+// tourismRefund returns the VAT refunded to the tourist (importe reintegro): the VAT of the hotel items (tourism codes 1 and 2).
+func tourismRefund(inv *bill.Invoice) num.Amount {
+	refund := num.MakeAmount(0, 2)
+	if inv == nil || inv.Tax == nil || inv.Totals == nil || inv.Totals.Taxes == nil ||
+		!slices.Contains(arca.DocTypesT, cbc.Code(inv.Tax.Ext.Get(arca.ExtKeyDocType).String())) {
+		return refund
+	}
+	for _, cat := range inv.Totals.Taxes.Categories {
+		if cat.Code != tax.CategoryVAT {
+			continue
+		}
+		for _, rate := range cat.Rates {
+			if ti := rate.Ext.Get(arca.ExtKeyTourismItem); ti == "1" || ti == "2" {
+				refund = refund.Add(rate.Amount)
+			}
+		}
+	}
+	return refund
+}
+
+// TourismPayable returns the payable total less the refunded VAT, or the payable unchanged for non-tourism invoices.
+func TourismPayable(inv *bill.Invoice, payable num.Amount) num.Amount {
+	return payable.Subtract(tourismRefund(inv))
+}
+
+func customerLegend(party *org.Party, docType cbc.Code) string {
+	if slices.Contains(arca.DocTypesT, docType) {
+		return "CLIENTE DEL EXTERIOR"
+	}
 	if party.Ext.IsZero() {
 		return ""
 	}

--- a/components/regimes/ar/arca.templ
+++ b/components/regimes/ar/arca.templ
@@ -9,6 +9,7 @@ import (
 	"github.com/invopop/gobl.html/components/t"
 	"github.com/invopop/gobl.html/internal"
 	"github.com/invopop/gobl/addons/ar/arca"
+	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
@@ -19,6 +20,20 @@ import (
 templ ARCAVATLegend(doc internal.Document, party *org.Party, role string) {
 	if legend := arcaVATLegend(doc, party, role); legend != "" {
 		<div class="arca-vat-legend">{ legend }</div>
+	}
+}
+
+// ARCATourismRefund renders the refunded VAT row (importe reintegro) on Type T invoices, and nothing otherwise.
+templ ARCATourismRefund(inv *bill.Invoice) {
+	if refund := tourismRefund(inv); !refund.IsZero() {
+		<tr class="arca-reintegro">
+			<th>
+				@t.T("regimes.ar.vat_refund")
+			</th>
+			<td>
+				@t.LM(refund.Negate())
+			</td>
+		</tr>
 	}
 }
 
@@ -56,7 +71,7 @@ func arcaDocType(doc internal.Document) string {
 	return dt.String()
 }
 
-// ARCADocTypeLetter renders the ARCA document type letter box (A, B, or C)
+// ARCADocTypeLetter renders the ARCA document type letter box (A, B, C, or T)
 // in the invoice header, if the document has an ar-arca-doc-type extension.
 templ ARCADocTypeLetter(doc internal.Document) {
 	if letter, code := arcaDocTypeLetter(doc.GetExt()); letter != "" {
@@ -84,6 +99,8 @@ func arcaDocTypeLetter(ext tax.Extensions) (string, string) {
 		letter = "B"
 	case slices.Contains(arca.DocTypesC, code):
 		letter = "C"
+	case slices.Contains(arca.DocTypesT, code):
+		letter = "T"
 	default:
 		return "", ""
 	}

--- a/components/regimes/ar/arca_templ.go
+++ b/components/regimes/ar/arca_templ.go
@@ -17,6 +17,7 @@ import (
 	"github.com/invopop/gobl.html/components/t"
 	"github.com/invopop/gobl.html/internal"
 	"github.com/invopop/gobl/addons/ar/arca"
+	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
@@ -53,13 +54,61 @@ func ARCAVATLegend(doc internal.Document, party *org.Party, role string) templ.C
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(legend)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/regimes/ar/arca.templ`, Line: 21, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/regimes/ar/arca.templ`, Line: 22, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		return nil
+	})
+}
+
+// ARCATourismRefund renders the refunded VAT row (importe reintegro) on Type T invoices, and nothing otherwise.
+func ARCATourismRefund(inv *bill.Invoice) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var3 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var3 == nil {
+			templ_7745c5c3_Var3 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		if refund := tourismRefund(inv); !refund.IsZero() {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<tr class=\"arca-reintegro\"><th>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = t.T("regimes.ar.vat_refund").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</th><td>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = t.LM(refund.Negate()).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</td></tr>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -86,9 +135,9 @@ func TitleType(doc internal.Document) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var3 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var3 == nil {
-			templ_7745c5c3_Var3 = templ.NopComponent
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if isArgentine(doc) {
@@ -117,9 +166,9 @@ func titleType(doc internal.Document) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var4 == nil {
-			templ_7745c5c3_Var4 = templ.NopComponent
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if typ := arcaDocType(doc); typ != "" {
@@ -152,7 +201,7 @@ func arcaDocType(doc internal.Document) string {
 	return dt.String()
 }
 
-// ARCADocTypeLetter renders the ARCA document type letter box (A, B, or C)
+// ARCADocTypeLetter renders the ARCA document type letter box (A, B, C, or T)
 // in the invoice header, if the document has an ar-arca-doc-type extension.
 func ARCADocTypeLetter(doc internal.Document) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
@@ -170,39 +219,39 @@ func ARCADocTypeLetter(doc internal.Document) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var5 == nil {
-			templ_7745c5c3_Var5 = templ.NopComponent
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if letter, code := arcaDocTypeLetter(doc.GetExt()); letter != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div class=\"arca-doc-type\"><div class=\"letter\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(letter)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/regimes/ar/arca.templ`, Line: 64, Col: 31}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div><div class=\"code\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div class=\"arca-doc-type\"><div class=\"letter\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var7 string
-			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(code)
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(letter)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/regimes/ar/arca.templ`, Line: 65, Col: 27}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/regimes/ar/arca.templ`, Line: 79, Col: 31}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div><div class=\"code\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(code)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/regimes/ar/arca.templ`, Line: 80, Col: 27}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -228,6 +277,8 @@ func arcaDocTypeLetter(ext tax.Extensions) (string, string) {
 		letter = "B"
 	case slices.Contains(arca.DocTypesC, code):
 		letter = "C"
+	case slices.Contains(arca.DocTypesT, code):
+		letter = "T"
 	default:
 		return "", ""
 	}
@@ -250,9 +301,9 @@ func ARCAQR(env *gobl.Envelope) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if cae := arcaCAE(env); cae != "" {
@@ -285,25 +336,25 @@ func generateQR(cae, caeExpiry, qr string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<style type=\"text/css\">\n        .arca-qr {\n\t\t\tdisplay: flex;\n            font-family: sans-serif;\n            font-size: 9pt;\n        }\n\t\t.arca-qr .image {\n\t\t\tmargin-right: 6mm;\n\t\t}\n\t\t.arca-qr .text {\n\t\t\tmargin-top: auto;\n\t\t\tmargin-bottom: auto;\n\t\t}\n\t\t.arca-qr .text .cae {\n\t\t\tfont-weight: bold;\n\t\t\tmargin-bottom: 2mm;\n\t\t}\n        .arca-qr img {\n            width: 24mm;\n            height: 24mm;\n        }\n    </style><section class=\"arca-qr\"><div class=\"image\"><a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<style type=\"text/css\">\n        .arca-qr {\n\t\t\tdisplay: flex;\n            font-family: sans-serif;\n            font-size: 9pt;\n        }\n\t\t.arca-qr .image {\n\t\t\tmargin-right: 6mm;\n\t\t}\n\t\t.arca-qr .text {\n\t\t\tmargin-top: auto;\n\t\t\tmargin-bottom: auto;\n\t\t}\n\t\t.arca-qr .text .cae {\n\t\t\tfont-weight: bold;\n\t\t\tmargin-bottom: 2mm;\n\t\t}\n        .arca-qr img {\n            width: 24mm;\n            height: 24mm;\n        }\n    </style><section class=\"arca-qr\"><div class=\"image\"><a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var10 templ.SafeURL
-		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(qr))
+		var templ_7745c5c3_Var11 templ.SafeURL
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(qr))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/regimes/ar/arca.templ`, Line: 128, Col: 26}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/regimes/ar/arca.templ`, Line: 145, Col: 26}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -311,33 +362,33 @@ func generateQR(cae, caeExpiry, qr string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</a></div><div class=\"text\"><div class=\"cae\">CAE N°: ")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var11 string
-		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(cae)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/regimes/ar/arca.templ`, Line: 134, Col: 18}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div><div class=\"cae-expiry\">Fecha de Vto. de CAE: ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</a></div><div class=\"text\"><div class=\"cae\">CAE N°: ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var12 string
-		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(caeExpiry)
+		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(cae)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/regimes/ar/arca.templ`, Line: 137, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/regimes/ar/arca.templ`, Line: 151, Col: 18}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div><div class=\"cae-expiry\">Fecha de Vto. de CAE: ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var13 string
+		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(caeExpiry)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/regimes/ar/arca.templ`, Line: 154, Col: 37}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div></div></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/examples/ar-arca-t-invoice-included.json
+++ b/examples/ar-arca-t-invoice-included.json
@@ -1,0 +1,122 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "9b62fd30-3b38-11ef-be56-0242ac120003",
+		"dig": {
+			"alg": "sha256",
+			"val": "1019b31ee1c01749ca0d70ac2d572d61c85416ef54d9dff43dbf7fb22def5078"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "AR",
+		"$addons": [
+			"ar-arca-v4"
+		],
+		"uuid": "1c5f531e-d146-c353-b835-6a6068cf5dc4",
+		"type": "standard",
+		"series": "1",
+		"code": "00000002",
+		"issue_date": "2025-02-01",
+		"currency": "ARS",
+		"tax": {
+			"prices_include": "VAT",
+			"ext": {
+				"ar-arca-concept": "2",
+				"ar-arca-doc-type": "195",
+				"ar-arca-tourism-type": "1"
+			}
+		},
+		"supplier": {
+			"name": "Hotel Patagonia S.A.",
+			"tax_id": {
+				"country": "AR",
+				"code": "30712345671"
+			},
+			"addresses": [
+				{
+					"street": "Av. San Martín 500",
+					"locality": "Bariloche",
+					"region": "Río Negro",
+					"code": "R8400",
+					"country": "AR"
+				}
+			]
+		},
+		"customer": {
+			"name": "John Smith",
+			"identities": [
+				{
+					"code": "AB123456",
+					"ext": {
+						"ar-arca-identity-type": "94"
+					}
+				}
+			],
+			"addresses": [
+				{
+					"street": "123 Main St",
+					"locality": "New York",
+					"region": "NY",
+					"country": "US"
+				}
+			],
+			"ext": {
+				"ar-arca-vat-status": "5"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "3",
+				"item": {
+					"name": "Hotel sin desayuno",
+					"price": "100.00"
+				},
+				"sum": "300.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%",
+						"ext": {
+							"ar-arca-tourism-item": "1",
+							"ar-arca-vat-rate": "5"
+						}
+					}
+				],
+				"total": "300.00"
+			}
+		],
+		"totals": {
+			"sum": "300.00",
+			"tax_included": "52.07",
+			"total": "247.93",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"ar-arca-tourism-item": "1",
+									"ar-arca-vat-rate": "5"
+								},
+								"base": "247.93",
+								"percent": "21.0%",
+								"amount": "52.07"
+							}
+						],
+						"amount": "52.07"
+					}
+				],
+				"sum": "52.07"
+			},
+			"tax": "52.07",
+			"total_with_tax": "300.00",
+			"payable": "300.00"
+		}
+	}
+}

--- a/examples/ar-arca-t-invoice.json
+++ b/examples/ar-arca-t-invoice.json
@@ -1,0 +1,120 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "9b62fd30-3b38-11ef-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "72bc2b6e8381fe19256982f87f0ed0cb6b43f7a7d3309ab947a7ffc972ee4b5c"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "AR",
+		"$addons": [
+			"ar-arca-v4"
+		],
+		"uuid": "1c5f531e-d146-c353-b835-6a6068cf5dc3",
+		"type": "standard",
+		"series": "1",
+		"code": "00000001",
+		"issue_date": "2025-02-01",
+		"currency": "ARS",
+		"tax": {
+			"ext": {
+				"ar-arca-concept": "2",
+				"ar-arca-doc-type": "195",
+				"ar-arca-tourism-type": "1"
+			}
+		},
+		"supplier": {
+			"name": "Hotel Patagonia S.A.",
+			"tax_id": {
+				"country": "AR",
+				"code": "30712345671"
+			},
+			"addresses": [
+				{
+					"street": "Av. San Martín 500",
+					"locality": "Bariloche",
+					"region": "Río Negro",
+					"code": "R8400",
+					"country": "AR"
+				}
+			]
+		},
+		"customer": {
+			"name": "John Smith",
+			"identities": [
+				{
+					"code": "AB123456",
+					"ext": {
+						"ar-arca-identity-type": "94"
+					}
+				}
+			],
+			"addresses": [
+				{
+					"street": "123 Main St",
+					"locality": "New York",
+					"region": "NY",
+					"country": "US"
+				}
+			],
+			"ext": {
+				"ar-arca-vat-status": "5"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "3",
+				"item": {
+					"name": "Hotel sin desayuno",
+					"price": "100.00"
+				},
+				"sum": "300.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%",
+						"ext": {
+							"ar-arca-tourism-item": "1",
+							"ar-arca-vat-rate": "5"
+						}
+					}
+				],
+				"total": "300.00"
+			}
+		],
+		"totals": {
+			"sum": "300.00",
+			"total": "300.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"ar-arca-tourism-item": "1",
+									"ar-arca-vat-rate": "5"
+								},
+								"base": "300.00",
+								"percent": "21.0%",
+								"amount": "63.00"
+							}
+						],
+						"amount": "63.00"
+					}
+				],
+				"sum": "63.00"
+			},
+			"tax": "63.00",
+			"total_with_tax": "363.00",
+			"payable": "363.00"
+		}
+	}
+}

--- a/examples/index.html
+++ b/examples/index.html
@@ -316,6 +316,48 @@ body { margin: 0; font-family: ui-sans-serif, system-ui, sans-serif; background:
 	</div>
 </a>
 
+<a class="card" id="ar-arca-t-invoice-included" href="#ar-arca-t-invoice-included-pdf" >
+	<div class="card-header">
+		<div data-avatar class="card-avatar">
+			<img class="card-avatar-img" src="https://assets.invopop.com/flags/ar.svg" alt="" width="16" height="16" loading="lazy" decoding="async">
+		</div>
+		<div class="card-title">
+			ar-arca-t-invoice-included
+		</div>
+	</div>
+	<div class="preview" id="ar-arca-t-invoice-included-pdf" data-active-tab="pdf">
+		<div role="tablist" aria-label="Preview format" class="preview-tabs">
+			<button type="button" role="tab" class="preview-tab" id="ar-arca-t-invoice-included-tab-pdf" data-tab="pdf" data-state="active" aria-selected="true" aria-controls="ar-arca-t-invoice-included-iframe-pdf">PDF</button>
+			<button type="button" role="tab" class="preview-tab" id="ar-arca-t-invoice-included-tab-html" data-tab="html" data-state="inactive" aria-selected="false" aria-controls="ar-arca-t-invoice-included-iframe-html" tabindex="-1">HTML</button>
+		</div>
+		<div class="preview-viewport">
+			<iframe class="preview-pdf" id="ar-arca-t-invoice-included-iframe-pdf" src="/ar-arca-t-invoice-included.pdf?locale=es#view=Fit&amp;toolbar=0" title="ar-arca-t-invoice-included (PDF)" tabindex="-1" loading="lazy"></iframe>
+			<iframe class="preview-html" id="ar-arca-t-invoice-included-iframe-html" src="/ar-arca-t-invoice-included.html?locale=es" title="ar-arca-t-invoice-included (HTML)" tabindex="-1" loading="lazy"></iframe>
+		</div>
+	</div>
+</a>
+
+<a class="card" id="ar-arca-t-invoice" href="#ar-arca-t-invoice-pdf" >
+	<div class="card-header">
+		<div data-avatar class="card-avatar">
+			<img class="card-avatar-img" src="https://assets.invopop.com/flags/ar.svg" alt="" width="16" height="16" loading="lazy" decoding="async">
+		</div>
+		<div class="card-title">
+			ar-arca-t-invoice
+		</div>
+	</div>
+	<div class="preview" id="ar-arca-t-invoice-pdf" data-active-tab="pdf">
+		<div role="tablist" aria-label="Preview format" class="preview-tabs">
+			<button type="button" role="tab" class="preview-tab" id="ar-arca-t-invoice-tab-pdf" data-tab="pdf" data-state="active" aria-selected="true" aria-controls="ar-arca-t-invoice-iframe-pdf">PDF</button>
+			<button type="button" role="tab" class="preview-tab" id="ar-arca-t-invoice-tab-html" data-tab="html" data-state="inactive" aria-selected="false" aria-controls="ar-arca-t-invoice-iframe-html" tabindex="-1">HTML</button>
+		</div>
+		<div class="preview-viewport">
+			<iframe class="preview-pdf" id="ar-arca-t-invoice-iframe-pdf" src="/ar-arca-t-invoice.pdf?locale=es#view=Fit&amp;toolbar=0" title="ar-arca-t-invoice (PDF)" tabindex="-1" loading="lazy"></iframe>
+			<iframe class="preview-html" id="ar-arca-t-invoice-iframe-html" src="/ar-arca-t-invoice.html?locale=es" title="ar-arca-t-invoice (HTML)" tabindex="-1" loading="lazy"></iframe>
+		</div>
+	</div>
+</a>
+
 <a class="card" id="co-dian-invoice" href="#co-dian-invoice-pdf" >
 	<div class="card-header">
 		<div data-avatar class="card-avatar">

--- a/examples/out/ar-arca-t-invoice-included.html
+++ b/examples/out/ar-arca-t-invoice-included.html
@@ -1,0 +1,350 @@
+<html data-theme="light">
+  <head>
+    <title>
+      GOBL HTML Generator
+    </title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/envelope.css">
+    <link rel="stylesheet" href="styles/invoice.css">
+  </head>
+  <body>
+    <article class="envelope">
+      <footer class="print">
+        <span class="page">
+          Page
+          <span class="page-number">
+            1
+          </span>
+          of
+          <span class="pages-number">
+            1
+          </span>
+        </span>
+        <div class="gobl-logo">
+          <a href="https://gobl.org">
+            <img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI1LjQuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkNhcGFfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiCgkgdmlld0JveD0iMCAwIDE4MC42IDIxOC44IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAxODAuNiAyMTguODsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8Zz4KCTxwYXRoIGQ9Ik0xNzIsMTI3LjVWMzIuNmMwLTEuNC0wLjctMi44LTEuOS0zLjZjLTEuMi0wLjgtMi43LTAuOS00LTAuM2wtMzguOCwxNi44di0yN2MwLTEuNC0wLjctMi44LTEuOS0zLjYKCQljLTEuMi0wLjgtMi43LTAuOS00LTAuNEw4Mi42LDMxLjN2LTI3YzAtMS40LTAuNy0yLjgtMS45LTMuNmMtMS4yLTAuOC0yLjctMC45LTQtMC40TDExLDI4LjdjLTEuNiwwLjctMi42LDIuMi0yLjYsMy45djk0LjkKCQljMCwxLjQsMC43LDIuOCwxLjksMy42YzAuNywwLjUsMS41LDAuNywyLjMsMC43YzAuNiwwLDEuMS0wLjEsMS43LTAuM2wzOC44LTE2Ljh2MjdjMCwxLjQsMC43LDIuOCwxLjksMy42CgkJYzAuNywwLjUsMS41LDAuNywyLjMsMC43YzAuNiwwLDEuMS0wLjEsMS43LTAuM2wzOC44LTE2Ljh2MjdjMCwxLjQsMC43LDIuOCwxLjksMy42YzAuNywwLjUsMS41LDAuNywyLjMsMC43CgkJYzAuNiwwLDEuMS0wLjEsMS43LTAuM2w2NS42LTI4LjRDMTcxLDEzMC44LDE3MiwxMjkuMiwxNzIsMTI3LjV6IE0xNjMuNSwxMjQuN2wtNTcuMSwyNC43di0yNC4ybDE4LjMtNy45YzEuNi0wLjcsMi42LTIuMiwyLjYtMy45CgkJVjY0bC04LjUsMy43djQyLjhsLTEyLjQsNS40bC04LjUsMy43bC0zNi4yLDE1LjZWMTExbDE4LjMtNy45YzEuNi0wLjcsMi42LTIuMiwyLjYtMy45VjQ5LjhsLTguNSwzLjd2NDIuOGwtMTIuNCw1LjRsLTguNSwzLjcKCQlMMTcsMTIxVjM1LjRsNTcuMS0yNC43VjM1bC0xOC4zLDcuOWMtMS42LDAuNy0yLjYsMi4yLTIuNiwzLjl2NDkuM2w4LjUtMy43VjQ5LjZsMTIuNC01LjRsOC41LTMuN2wzNi4yLTE1LjZ2MjQuMmwtMTguMyw3LjkKCQljLTEuNiwwLjctMi42LDIuMi0yLjYsMy45djQ5LjNsOC41LTMuN1Y2My44bDEyLjQtNS40bDguNS0zLjdsMzYuMi0xNS42VjEyNC43eiIvPgoJPGc+CgkJPGc+CgkJCTxwYXRoIGQ9Ik00NC4yLDE4Ny40Yy0yLjMtNy4xLTkuNC0xMS40LTIwLjEtMTEuNEM5LjEsMTc2LDAsMTg0LjcsMCwxOTcuNGMwLDEzLDkuMSwyMS41LDIzLDIxLjVjMTYsMCwyMi45LTguNiwyMi45LTIwLjUKCQkJCWMwLTEuMiwwLTIuNS0wLjMtMy44SDIzLjJ2N2gxMi41YzAuMiw1LjYtNS4yLDkuNC0xMS45LDkuNGMtOC42LDAtMTMtNS4zLTEzLTEzLjZjMC04LjMsNC41LTEzLjgsMTIuMy0xMy44CgkJCQljNC42LDAsOC40LDEuOSw5LjksNi4yTDQ0LjIsMTg3LjR6Ii8+CgkJCTxwYXRoIGQ9Ik03NC42LDIxMC45Yy03LjYsMC0xMi40LTUuMy0xMi40LTEzLjVjMC04LjMsNC44LTEzLjUsMTIuNC0xMy41YzcuNiwwLDEyLjQsNS4yLDEyLjQsMTMuNQoJCQkJQzg3LDIwNS43LDgyLjIsMjEwLjksNzQuNiwyMTAuOXogTTc0LjYsMjE4LjhjMTQsMCwyMy4xLTguMywyMy4xLTIxLjRjMC0xMy4xLTkuMS0yMS40LTIzLjEtMjEuNHMtMjMuMSw4LjMtMjMuMSwyMS40CgkJCQlDNTEuNiwyMTAuNSw2MC43LDIxOC44LDc0LjYsMjE4Ljh6Ii8+CgkJCTxwYXRoIGQ9Ik0xMjUsMjEwLjdoLTExLjJ2LTEwLjNoMTEuM2M0LjIsMCw2LjMsMiw2LjMsNS4xQzEzMS40LDIwOC40LDEyOS40LDIxMC43LDEyNSwyMTAuN3ogTTExMy44LDE4NC4yaDEwLjYKCQkJCWM0LjMsMCw1LjksMi4xLDUuOSw0LjZjMCwyLjYtMS40LDQuOS01LjksNC45aC0xMC42VjE4NC4yeiBNMTMzLjQsMTk2LjVjNS0xLjIsNy42LTQuNyw3LjYtOWMwLTUuOS00LjMtMTAuMy0xMy44LTEwLjNoLTIzLjYKCQkJCXY0MC41aDI0LjFjOS45LDAsMTQuNC01LjEsMTQuNC0xMS41QzE0Mi4xLDIwMC45LDEzOS4xLDE5Ny40LDEzMy40LDE5Ni41eiIvPgoJCQk8cG9seWdvbiBwb2ludHM9IjE0OS4yLDE3Ny4yIDE0OS4yLDIxNy43IDE4MC42LDIxNy43IDE4MC42LDIwOS41IDE1OS40LDIwOS41IDE1OS40LDE3Ny4yIAkJCSIvPgoJCTwvZz4KCTwvZz4KPC9nPgo8L3N2Zz4K" alt="GOBL">
+          </a>
+        </div>
+      </footer>
+      <article class="invoice">
+        <header class="regular">
+          <div class="details">
+            <section class="title">
+              <div class="hero">
+                <div class="alias">
+                  Hotel Patagonia S.A.
+                </div>
+                <div class="arca-doc-type">
+                  <div class="letter">
+                    T
+                  </div>
+                  <div class="code">
+                    Cod. 195
+                  </div>
+                </div>
+              </div>
+              <div class="title-group">
+                <h1 class="type">
+                  Invoice Class T
+                </h1>
+                <h2 class="code">
+                  1-00000002
+                </h2>
+              </div>
+            </section>
+            <section class="summary">
+              <h2 class="title">
+                Summary
+              </h2>
+              <ul>
+                <li class="issue-date">
+                  <span class="label">
+                    Issue date
+                  </span>
+                  <span class="value date">
+                    2025-02-01
+                  </span>
+                </li>
+                <li class="currency">
+                  <span class="label">
+                    Currency
+                  </span>
+                  <span class="value">
+                    Argentine Peso (ARS)
+                  </span>
+                </li>
+              </ul>
+            </section>
+          </div>
+          <div class="contacts">
+            <section class="supplier">
+              <div class="party-border">
+                <h2>
+                  Supplier
+                </h2>
+                <div class="org-party">
+                  <div class="name">
+                    Hotel Patagonia S.A.
+                  </div>
+                  <div class="org-address">
+                    <span>
+                      Av. San Martín 500, Bariloche, Río Negro, R8400 (Argentina)
+                    </span>
+                  </div>
+                  <div class="tax-id">
+                    CUIT: (AR) 30712345671
+                  </div>
+                  <div class="arca-vat-legend">
+                    IVA RESPONSABLE INSCRIPTO
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section class="customer">
+              <div class="party-border">
+                <h2>
+                  Customer
+                </h2>
+                <div class="org-party">
+                  <div class="name">
+                    John Smith
+                  </div>
+                  <div class="org-address">
+                    <span>
+                      123 Main St, New York, NY (United States of America)
+                    </span>
+                  </div>
+                  <div class="identitiy">
+                    Identity code: AB123456
+                  </div>
+                  <div class="arca-vat-legend">
+                    CLIENTE DEL EXTERIOR
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </header>
+        <section class="lines">
+          <h2>
+            Lines
+          </h2>
+          <table>
+            <thead>
+              <tr>
+                <th class="ref">
+                  #
+                </th>
+                <th class="description">
+                  Description
+                </th>
+                <th class="quantity">
+                  Qty.
+                </th>
+                <th class="price">
+                  Price
+                </th>
+                <th class="tax">
+                  VAT
+                </th>
+                <th class="total">
+                  Total
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-subtotal="$300,00">
+                <td class="ref">
+                  1
+                </td>
+                <td class="description">
+                  <div class="limited-height">
+                    <span>
+                      Hotel sin desayuno
+                    </span>
+                  </div>
+                </td>
+                <td class="quantity">
+                  3
+                </td>
+                <td class="price">
+                  $100,00
+                </td>
+                <td class="tax">
+                  21,0%
+                </td>
+                <td class="total">
+                  $300,00
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+        <div class="tail">
+          <div class="totals">
+            <section class="totals">
+              <h2>
+                Totals
+              </h2>
+              <table>
+                <tbody>
+                  <tr class="sum strong">
+                    <th>
+                      Sum
+                    </th>
+                    <td>
+                      $300,00
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>
+                      Included VAT
+                    </th>
+                    <td>
+                      $52,07
+                    </td>
+                  </tr>
+                  <tr class="total">
+                    <th>
+                      Total
+                    </th>
+                    <td>
+                      $247,93
+                    </td>
+                  </tr>
+                  <tr class="arca-reintegro">
+                    <th>
+                      VAT Refund
+                    </th>
+                    <td>
+                      $-52,07
+                    </td>
+                  </tr>
+                  <tr class="payable strong">
+                    <th>
+                      Total to pay
+                    </th>
+                    <td>
+                      $247,93
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </section>
+            <section class="taxes">
+              <h2>
+                Taxes
+              </h2>
+              <table>
+                <thead>
+                  <tr>
+                    <th class="category">
+                      Tax
+                    </th>
+                    <th class="base">
+                      Base
+                    </th>
+                    <th class="rate">
+                      Rate
+                    </th>
+                    <th class="amount">
+                      Amount
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td rowspan="1" class="category">
+                      VAT
+                    </td>
+                    <td class="base">
+                      $247,93
+                    </td>
+                    <td class="rate">
+                      21,0%
+                    </td>
+                    <td class="amount">
+                      $52,07
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </section>
+          </div>
+          <div class="extensions"></div>
+        </div>
+      </article>
+      <div id="mp-header-templ" class="mp-header">
+        <div class="totals">
+          <section class="totals">
+            <table>
+              <tbody>
+                <tr class="strong">
+                  <th>
+                    Brought forward
+                  </th>
+                  <td class="amount">
+                    $0,00
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section class="title">
+            <div class="hero">
+              <div class="alias">
+                Hotel Patagonia S.A.
+              </div>
+              <div class="arca-doc-type">
+                <div class="letter">
+                  T
+                </div>
+                <div class="code">
+                  Cod. 195
+                </div>
+              </div>
+            </div>
+            <div class="title-group">
+              <h1 class="type">
+                Invoice Class T
+              </h1>
+              <h2 class="code">
+                1-00000002
+              </h2>
+            </div>
+          </section>
+        </div>
+      </div>
+      <div id="mp-footer-templ" class="mp-footer">
+        <div class="totals">
+          <section class="totals">
+            <table>
+              <tbody>
+                <tr class="strong">
+                  <th>
+                    Carried forward
+                  </th>
+                  <td class="amount">
+                    $0,00
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+        </div>
+      </div>
+      <script src="scripts/multipage.js"></script>
+      <footer class="screen">
+        <div class="gobl-logo">
+          <a href="https://gobl.org">
+            <img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI1LjQuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkNhcGFfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiCgkgdmlld0JveD0iMCAwIDE4MC42IDIxOC44IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAxODAuNiAyMTguODsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8Zz4KCTxwYXRoIGQ9Ik0xNzIsMTI3LjVWMzIuNmMwLTEuNC0wLjctMi44LTEuOS0zLjZjLTEuMi0wLjgtMi43LTAuOS00LTAuM2wtMzguOCwxNi44di0yN2MwLTEuNC0wLjctMi44LTEuOS0zLjYKCQljLTEuMi0wLjgtMi43LTAuOS00LTAuNEw4Mi42LDMxLjN2LTI3YzAtMS40LTAuNy0yLjgtMS45LTMuNmMtMS4yLTAuOC0yLjctMC45LTQtMC40TDExLDI4LjdjLTEuNiwwLjctMi42LDIuMi0yLjYsMy45djk0LjkKCQljMCwxLjQsMC43LDIuOCwxLjksMy42YzAuNywwLjUsMS41LDAuNywyLjMsMC43YzAuNiwwLDEuMS0wLjEsMS43LTAuM2wzOC44LTE2Ljh2MjdjMCwxLjQsMC43LDIuOCwxLjksMy42CgkJYzAuNywwLjUsMS41LDAuNywyLjMsMC43YzAuNiwwLDEuMS0wLjEsMS43LTAuM2wzOC44LTE2Ljh2MjdjMCwxLjQsMC43LDIuOCwxLjksMy42YzAuNywwLjUsMS41LDAuNywyLjMsMC43CgkJYzAuNiwwLDEuMS0wLjEsMS43LTAuM2w2NS42LTI4LjRDMTcxLDEzMC44LDE3MiwxMjkuMiwxNzIsMTI3LjV6IE0xNjMuNSwxMjQuN2wtNTcuMSwyNC43di0yNC4ybDE4LjMtNy45YzEuNi0wLjcsMi42LTIuMiwyLjYtMy45CgkJVjY0bC04LjUsMy43djQyLjhsLTEyLjQsNS40bC04LjUsMy43bC0zNi4yLDE1LjZWMTExbDE4LjMtNy45YzEuNi0wLjcsMi42LTIuMiwyLjYtMy45VjQ5LjhsLTguNSwzLjd2NDIuOGwtMTIuNCw1LjRsLTguNSwzLjcKCQlMMTcsMTIxVjM1LjRsNTcuMS0yNC43VjM1bC0xOC4zLDcuOWMtMS42LDAuNy0yLjYsMi4yLTIuNiwzLjl2NDkuM2w4LjUtMy43VjQ5LjZsMTIuNC01LjRsOC41LTMuN2wzNi4yLTE1LjZ2MjQuMmwtMTguMyw3LjkKCQljLTEuNiwwLjctMi42LDIuMi0yLjYsMy45djQ5LjNsOC41LTMuN1Y2My44bDEyLjQtNS40bDguNS0zLjdsMzYuMi0xNS42VjEyNC43eiIvPgoJPGc+CgkJPGc+CgkJCTxwYXRoIGQ9Ik00NC4yLDE4Ny40Yy0yLjMtNy4xLTkuNC0xMS40LTIwLjEtMTEuNEM5LjEsMTc2LDAsMTg0LjcsMCwxOTcuNGMwLDEzLDkuMSwyMS41LDIzLDIxLjVjMTYsMCwyMi45LTguNiwyMi45LTIwLjUKCQkJCWMwLTEuMiwwLTIuNS0wLjMtMy44SDIzLjJ2N2gxMi41YzAuMiw1LjYtNS4yLDkuNC0xMS45LDkuNGMtOC42LDAtMTMtNS4zLTEzLTEzLjZjMC04LjMsNC41LTEzLjgsMTIuMy0xMy44CgkJCQljNC42LDAsOC40LDEuOSw5LjksNi4yTDQ0LjIsMTg3LjR6Ii8+CgkJCTxwYXRoIGQ9Ik03NC42LDIxMC45Yy03LjYsMC0xMi40LTUuMy0xMi40LTEzLjVjMC04LjMsNC44LTEzLjUsMTIuNC0xMy41YzcuNiwwLDEyLjQsNS4yLDEyLjQsMTMuNQoJCQkJQzg3LDIwNS43LDgyLjIsMjEwLjksNzQuNiwyMTAuOXogTTc0LjYsMjE4LjhjMTQsMCwyMy4xLTguMywyMy4xLTIxLjRjMC0xMy4xLTkuMS0yMS40LTIzLjEtMjEuNHMtMjMuMSw4LjMtMjMuMSwyMS40CgkJCQlDNTEuNiwyMTAuNSw2MC43LDIxOC44LDc0LjYsMjE4Ljh6Ii8+CgkJCTxwYXRoIGQ9Ik0xMjUsMjEwLjdoLTExLjJ2LTEwLjNoMTEuM2M0LjIsMCw2LjMsMiw2LjMsNS4xQzEzMS40LDIwOC40LDEyOS40LDIxMC43LDEyNSwyMTAuN3ogTTExMy44LDE4NC4yaDEwLjYKCQkJCWM0LjMsMCw1LjksMi4xLDUuOSw0LjZjMCwyLjYtMS40LDQuOS01LjksNC45aC0xMC42VjE4NC4yeiBNMTMzLjQsMTk2LjVjNS0xLjIsNy42LTQuNyw3LjYtOWMwLTUuOS00LjMtMTAuMy0xMy44LTEwLjNoLTIzLjYKCQkJCXY0MC41aDI0LjFjOS45LDAsMTQuNC01LjEsMTQuNC0xMS41QzE0Mi4xLDIwMC45LDEzOS4xLDE5Ny40LDEzMy40LDE5Ni41eiIvPgoJCQk8cG9seWdvbiBwb2ludHM9IjE0OS4yLDE3Ny4yIDE0OS4yLDIxNy43IDE4MC42LDIxNy43IDE4MC42LDIwOS41IDE1OS40LDIwOS41IDE1OS40LDE3Ny4yIAkJCSIvPgoJCTwvZz4KCTwvZz4KPC9nPgo8L3N2Zz4K" alt="GOBL">
+          </a>
+        </div>
+      </footer>
+    </article>
+  </body>
+</html>

--- a/examples/out/ar-arca-t-invoice.html
+++ b/examples/out/ar-arca-t-invoice.html
@@ -1,0 +1,342 @@
+<html data-theme="light">
+  <head>
+    <title>
+      GOBL HTML Generator
+    </title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/envelope.css">
+    <link rel="stylesheet" href="styles/invoice.css">
+  </head>
+  <body>
+    <article class="envelope">
+      <footer class="print">
+        <span class="page">
+          Page
+          <span class="page-number">
+            1
+          </span>
+          of
+          <span class="pages-number">
+            1
+          </span>
+        </span>
+        <div class="gobl-logo">
+          <a href="https://gobl.org">
+            <img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI1LjQuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkNhcGFfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiCgkgdmlld0JveD0iMCAwIDE4MC42IDIxOC44IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAxODAuNiAyMTguODsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8Zz4KCTxwYXRoIGQ9Ik0xNzIsMTI3LjVWMzIuNmMwLTEuNC0wLjctMi44LTEuOS0zLjZjLTEuMi0wLjgtMi43LTAuOS00LTAuM2wtMzguOCwxNi44di0yN2MwLTEuNC0wLjctMi44LTEuOS0zLjYKCQljLTEuMi0wLjgtMi43LTAuOS00LTAuNEw4Mi42LDMxLjN2LTI3YzAtMS40LTAuNy0yLjgtMS45LTMuNmMtMS4yLTAuOC0yLjctMC45LTQtMC40TDExLDI4LjdjLTEuNiwwLjctMi42LDIuMi0yLjYsMy45djk0LjkKCQljMCwxLjQsMC43LDIuOCwxLjksMy42YzAuNywwLjUsMS41LDAuNywyLjMsMC43YzAuNiwwLDEuMS0wLjEsMS43LTAuM2wzOC44LTE2Ljh2MjdjMCwxLjQsMC43LDIuOCwxLjksMy42CgkJYzAuNywwLjUsMS41LDAuNywyLjMsMC43YzAuNiwwLDEuMS0wLjEsMS43LTAuM2wzOC44LTE2Ljh2MjdjMCwxLjQsMC43LDIuOCwxLjksMy42YzAuNywwLjUsMS41LDAuNywyLjMsMC43CgkJYzAuNiwwLDEuMS0wLjEsMS43LTAuM2w2NS42LTI4LjRDMTcxLDEzMC44LDE3MiwxMjkuMiwxNzIsMTI3LjV6IE0xNjMuNSwxMjQuN2wtNTcuMSwyNC43di0yNC4ybDE4LjMtNy45YzEuNi0wLjcsMi42LTIuMiwyLjYtMy45CgkJVjY0bC04LjUsMy43djQyLjhsLTEyLjQsNS40bC04LjUsMy43bC0zNi4yLDE1LjZWMTExbDE4LjMtNy45YzEuNi0wLjcsMi42LTIuMiwyLjYtMy45VjQ5LjhsLTguNSwzLjd2NDIuOGwtMTIuNCw1LjRsLTguNSwzLjcKCQlMMTcsMTIxVjM1LjRsNTcuMS0yNC43VjM1bC0xOC4zLDcuOWMtMS42LDAuNy0yLjYsMi4yLTIuNiwzLjl2NDkuM2w4LjUtMy43VjQ5LjZsMTIuNC01LjRsOC41LTMuN2wzNi4yLTE1LjZ2MjQuMmwtMTguMyw3LjkKCQljLTEuNiwwLjctMi42LDIuMi0yLjYsMy45djQ5LjNsOC41LTMuN1Y2My44bDEyLjQtNS40bDguNS0zLjdsMzYuMi0xNS42VjEyNC43eiIvPgoJPGc+CgkJPGc+CgkJCTxwYXRoIGQ9Ik00NC4yLDE4Ny40Yy0yLjMtNy4xLTkuNC0xMS40LTIwLjEtMTEuNEM5LjEsMTc2LDAsMTg0LjcsMCwxOTcuNGMwLDEzLDkuMSwyMS41LDIzLDIxLjVjMTYsMCwyMi45LTguNiwyMi45LTIwLjUKCQkJCWMwLTEuMiwwLTIuNS0wLjMtMy44SDIzLjJ2N2gxMi41YzAuMiw1LjYtNS4yLDkuNC0xMS45LDkuNGMtOC42LDAtMTMtNS4zLTEzLTEzLjZjMC04LjMsNC41LTEzLjgsMTIuMy0xMy44CgkJCQljNC42LDAsOC40LDEuOSw5LjksNi4yTDQ0LjIsMTg3LjR6Ii8+CgkJCTxwYXRoIGQ9Ik03NC42LDIxMC45Yy03LjYsMC0xMi40LTUuMy0xMi40LTEzLjVjMC04LjMsNC44LTEzLjUsMTIuNC0xMy41YzcuNiwwLDEyLjQsNS4yLDEyLjQsMTMuNQoJCQkJQzg3LDIwNS43LDgyLjIsMjEwLjksNzQuNiwyMTAuOXogTTc0LjYsMjE4LjhjMTQsMCwyMy4xLTguMywyMy4xLTIxLjRjMC0xMy4xLTkuMS0yMS40LTIzLjEtMjEuNHMtMjMuMSw4LjMtMjMuMSwyMS40CgkJCQlDNTEuNiwyMTAuNSw2MC43LDIxOC44LDc0LjYsMjE4Ljh6Ii8+CgkJCTxwYXRoIGQ9Ik0xMjUsMjEwLjdoLTExLjJ2LTEwLjNoMTEuM2M0LjIsMCw2LjMsMiw2LjMsNS4xQzEzMS40LDIwOC40LDEyOS40LDIxMC43LDEyNSwyMTAuN3ogTTExMy44LDE4NC4yaDEwLjYKCQkJCWM0LjMsMCw1LjksMi4xLDUuOSw0LjZjMCwyLjYtMS40LDQuOS01LjksNC45aC0xMC42VjE4NC4yeiBNMTMzLjQsMTk2LjVjNS0xLjIsNy42LTQuNyw3LjYtOWMwLTUuOS00LjMtMTAuMy0xMy44LTEwLjNoLTIzLjYKCQkJCXY0MC41aDI0LjFjOS45LDAsMTQuNC01LjEsMTQuNC0xMS41QzE0Mi4xLDIwMC45LDEzOS4xLDE5Ny40LDEzMy40LDE5Ni41eiIvPgoJCQk8cG9seWdvbiBwb2ludHM9IjE0OS4yLDE3Ny4yIDE0OS4yLDIxNy43IDE4MC42LDIxNy43IDE4MC42LDIwOS41IDE1OS40LDIwOS41IDE1OS40LDE3Ny4yIAkJCSIvPgoJCTwvZz4KCTwvZz4KPC9nPgo8L3N2Zz4K" alt="GOBL">
+          </a>
+        </div>
+      </footer>
+      <article class="invoice">
+        <header class="regular">
+          <div class="details">
+            <section class="title">
+              <div class="hero">
+                <div class="alias">
+                  Hotel Patagonia S.A.
+                </div>
+                <div class="arca-doc-type">
+                  <div class="letter">
+                    T
+                  </div>
+                  <div class="code">
+                    Cod. 195
+                  </div>
+                </div>
+              </div>
+              <div class="title-group">
+                <h1 class="type">
+                  Invoice Class T
+                </h1>
+                <h2 class="code">
+                  1-00000001
+                </h2>
+              </div>
+            </section>
+            <section class="summary">
+              <h2 class="title">
+                Summary
+              </h2>
+              <ul>
+                <li class="issue-date">
+                  <span class="label">
+                    Issue date
+                  </span>
+                  <span class="value date">
+                    2025-02-01
+                  </span>
+                </li>
+                <li class="currency">
+                  <span class="label">
+                    Currency
+                  </span>
+                  <span class="value">
+                    Argentine Peso (ARS)
+                  </span>
+                </li>
+              </ul>
+            </section>
+          </div>
+          <div class="contacts">
+            <section class="supplier">
+              <div class="party-border">
+                <h2>
+                  Supplier
+                </h2>
+                <div class="org-party">
+                  <div class="name">
+                    Hotel Patagonia S.A.
+                  </div>
+                  <div class="org-address">
+                    <span>
+                      Av. San Martín 500, Bariloche, Río Negro, R8400 (Argentina)
+                    </span>
+                  </div>
+                  <div class="tax-id">
+                    CUIT: (AR) 30712345671
+                  </div>
+                  <div class="arca-vat-legend">
+                    IVA RESPONSABLE INSCRIPTO
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section class="customer">
+              <div class="party-border">
+                <h2>
+                  Customer
+                </h2>
+                <div class="org-party">
+                  <div class="name">
+                    John Smith
+                  </div>
+                  <div class="org-address">
+                    <span>
+                      123 Main St, New York, NY (United States of America)
+                    </span>
+                  </div>
+                  <div class="identitiy">
+                    Identity code: AB123456
+                  </div>
+                  <div class="arca-vat-legend">
+                    CLIENTE DEL EXTERIOR
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </header>
+        <section class="lines">
+          <h2>
+            Lines
+          </h2>
+          <table>
+            <thead>
+              <tr>
+                <th class="ref">
+                  #
+                </th>
+                <th class="description">
+                  Description
+                </th>
+                <th class="quantity">
+                  Qty.
+                </th>
+                <th class="price">
+                  Price
+                </th>
+                <th class="tax">
+                  VAT
+                </th>
+                <th class="total">
+                  Total
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-subtotal="$300,00">
+                <td class="ref">
+                  1
+                </td>
+                <td class="description">
+                  <div class="limited-height">
+                    <span>
+                      Hotel sin desayuno
+                    </span>
+                  </div>
+                </td>
+                <td class="quantity">
+                  3
+                </td>
+                <td class="price">
+                  $100,00
+                </td>
+                <td class="tax">
+                  21,0%
+                </td>
+                <td class="total">
+                  $300,00
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+        <div class="tail">
+          <div class="totals">
+            <section class="totals">
+              <h2>
+                Totals
+              </h2>
+              <table>
+                <tbody>
+                  <tr class="sum strong">
+                    <th>
+                      Sum
+                    </th>
+                    <td>
+                      $300,00
+                    </td>
+                  </tr>
+                  <tr class="tax">
+                    <th>
+                      Tax
+                    </th>
+                    <td>
+                      $63,00
+                    </td>
+                  </tr>
+                  <tr class="arca-reintegro">
+                    <th>
+                      VAT Refund
+                    </th>
+                    <td>
+                      $-63,00
+                    </td>
+                  </tr>
+                  <tr class="payable strong">
+                    <th>
+                      Total to pay
+                    </th>
+                    <td>
+                      $300,00
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </section>
+            <section class="taxes">
+              <h2>
+                Taxes
+              </h2>
+              <table>
+                <thead>
+                  <tr>
+                    <th class="category">
+                      Tax
+                    </th>
+                    <th class="base">
+                      Base
+                    </th>
+                    <th class="rate">
+                      Rate
+                    </th>
+                    <th class="amount">
+                      Amount
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td rowspan="1" class="category">
+                      VAT
+                    </td>
+                    <td class="base">
+                      $300,00
+                    </td>
+                    <td class="rate">
+                      21,0%
+                    </td>
+                    <td class="amount">
+                      $63,00
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </section>
+          </div>
+          <div class="extensions"></div>
+        </div>
+      </article>
+      <div id="mp-header-templ" class="mp-header">
+        <div class="totals">
+          <section class="totals">
+            <table>
+              <tbody>
+                <tr class="strong">
+                  <th>
+                    Brought forward
+                  </th>
+                  <td class="amount">
+                    $0,00
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section class="title">
+            <div class="hero">
+              <div class="alias">
+                Hotel Patagonia S.A.
+              </div>
+              <div class="arca-doc-type">
+                <div class="letter">
+                  T
+                </div>
+                <div class="code">
+                  Cod. 195
+                </div>
+              </div>
+            </div>
+            <div class="title-group">
+              <h1 class="type">
+                Invoice Class T
+              </h1>
+              <h2 class="code">
+                1-00000001
+              </h2>
+            </div>
+          </section>
+        </div>
+      </div>
+      <div id="mp-footer-templ" class="mp-footer">
+        <div class="totals">
+          <section class="totals">
+            <table>
+              <tbody>
+                <tr class="strong">
+                  <th>
+                    Carried forward
+                  </th>
+                  <td class="amount">
+                    $0,00
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+        </div>
+      </div>
+      <script src="scripts/multipage.js"></script>
+      <footer class="screen">
+        <div class="gobl-logo">
+          <a href="https://gobl.org">
+            <img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI1LjQuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkNhcGFfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiCgkgdmlld0JveD0iMCAwIDE4MC42IDIxOC44IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAxODAuNiAyMTguODsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8Zz4KCTxwYXRoIGQ9Ik0xNzIsMTI3LjVWMzIuNmMwLTEuNC0wLjctMi44LTEuOS0zLjZjLTEuMi0wLjgtMi43LTAuOS00LTAuM2wtMzguOCwxNi44di0yN2MwLTEuNC0wLjctMi44LTEuOS0zLjYKCQljLTEuMi0wLjgtMi43LTAuOS00LTAuNEw4Mi42LDMxLjN2LTI3YzAtMS40LTAuNy0yLjgtMS45LTMuNmMtMS4yLTAuOC0yLjctMC45LTQtMC40TDExLDI4LjdjLTEuNiwwLjctMi42LDIuMi0yLjYsMy45djk0LjkKCQljMCwxLjQsMC43LDIuOCwxLjksMy42YzAuNywwLjUsMS41LDAuNywyLjMsMC43YzAuNiwwLDEuMS0wLjEsMS43LTAuM2wzOC44LTE2Ljh2MjdjMCwxLjQsMC43LDIuOCwxLjksMy42CgkJYzAuNywwLjUsMS41LDAuNywyLjMsMC43YzAuNiwwLDEuMS0wLjEsMS43LTAuM2wzOC44LTE2Ljh2MjdjMCwxLjQsMC43LDIuOCwxLjksMy42YzAuNywwLjUsMS41LDAuNywyLjMsMC43CgkJYzAuNiwwLDEuMS0wLjEsMS43LTAuM2w2NS42LTI4LjRDMTcxLDEzMC44LDE3MiwxMjkuMiwxNzIsMTI3LjV6IE0xNjMuNSwxMjQuN2wtNTcuMSwyNC43di0yNC4ybDE4LjMtNy45YzEuNi0wLjcsMi42LTIuMiwyLjYtMy45CgkJVjY0bC04LjUsMy43djQyLjhsLTEyLjQsNS40bC04LjUsMy43bC0zNi4yLDE1LjZWMTExbDE4LjMtNy45YzEuNi0wLjcsMi42LTIuMiwyLjYtMy45VjQ5LjhsLTguNSwzLjd2NDIuOGwtMTIuNCw1LjRsLTguNSwzLjcKCQlMMTcsMTIxVjM1LjRsNTcuMS0yNC43VjM1bC0xOC4zLDcuOWMtMS42LDAuNy0yLjYsMi4yLTIuNiwzLjl2NDkuM2w4LjUtMy43VjQ5LjZsMTIuNC01LjRsOC41LTMuN2wzNi4yLTE1LjZ2MjQuMmwtMTguMyw3LjkKCQljLTEuNiwwLjctMi42LDIuMi0yLjYsMy45djQ5LjNsOC41LTMuN1Y2My44bDEyLjQtNS40bDguNS0zLjdsMzYuMi0xNS42VjEyNC43eiIvPgoJPGc+CgkJPGc+CgkJCTxwYXRoIGQ9Ik00NC4yLDE4Ny40Yy0yLjMtNy4xLTkuNC0xMS40LTIwLjEtMTEuNEM5LjEsMTc2LDAsMTg0LjcsMCwxOTcuNGMwLDEzLDkuMSwyMS41LDIzLDIxLjVjMTYsMCwyMi45LTguNiwyMi45LTIwLjUKCQkJCWMwLTEuMiwwLTIuNS0wLjMtMy44SDIzLjJ2N2gxMi41YzAuMiw1LjYtNS4yLDkuNC0xMS45LDkuNGMtOC42LDAtMTMtNS4zLTEzLTEzLjZjMC04LjMsNC41LTEzLjgsMTIuMy0xMy44CgkJCQljNC42LDAsOC40LDEuOSw5LjksNi4yTDQ0LjIsMTg3LjR6Ii8+CgkJCTxwYXRoIGQ9Ik03NC42LDIxMC45Yy03LjYsMC0xMi40LTUuMy0xMi40LTEzLjVjMC04LjMsNC44LTEzLjUsMTIuNC0xMy41YzcuNiwwLDEyLjQsNS4yLDEyLjQsMTMuNQoJCQkJQzg3LDIwNS43LDgyLjIsMjEwLjksNzQuNiwyMTAuOXogTTc0LjYsMjE4LjhjMTQsMCwyMy4xLTguMywyMy4xLTIxLjRjMC0xMy4xLTkuMS0yMS40LTIzLjEtMjEuNHMtMjMuMSw4LjMtMjMuMSwyMS40CgkJCQlDNTEuNiwyMTAuNSw2MC43LDIxOC44LDc0LjYsMjE4Ljh6Ii8+CgkJCTxwYXRoIGQ9Ik0xMjUsMjEwLjdoLTExLjJ2LTEwLjNoMTEuM2M0LjIsMCw2LjMsMiw2LjMsNS4xQzEzMS40LDIwOC40LDEyOS40LDIxMC43LDEyNSwyMTAuN3ogTTExMy44LDE4NC4yaDEwLjYKCQkJCWM0LjMsMCw1LjksMi4xLDUuOSw0LjZjMCwyLjYtMS40LDQuOS01LjksNC45aC0xMC42VjE4NC4yeiBNMTMzLjQsMTk2LjVjNS0xLjIsNy42LTQuNyw3LjYtOWMwLTUuOS00LjMtMTAuMy0xMy44LTEwLjNoLTIzLjYKCQkJCXY0MC41aDI0LjFjOS45LDAsMTQuNC01LjEsMTQuNC0xMS41QzE0Mi4xLDIwMC45LDEzOS4xLDE5Ny40LDEzMy40LDE5Ni41eiIvPgoJCQk8cG9seWdvbiBwb2ludHM9IjE0OS4yLDE3Ny4yIDE0OS4yLDIxNy43IDE4MC42LDIxNy43IDE4MC42LDIwOS41IDE1OS40LDIwOS41IDE1OS40LDE3Ny4yIAkJCSIvPgoJCTwvZz4KCTwvZz4KPC9nPgo8L3N2Zz4K" alt="GOBL">
+          </a>
+        </div>
+      </footer>
+    </article>
+  </body>
+</html>

--- a/locales/en/app.yml
+++ b/locales/en/app.yml
@@ -335,6 +335,7 @@ en:
           5: "Expense adjustment (accounting base)" # "Other expense adjustment/Regularization entries – Accounting base"
           6: "Expense adjustment (tax base)" # "Other expense adjustment/Regularization entries – Tax base"
     ar:
+      vat_refund: "VAT Refund"
       title:
         "1": "Invoice A"
         "2": "Debit Note A"

--- a/locales/es/app.yml
+++ b/locales/es/app.yml
@@ -256,6 +256,7 @@ es:
 
   regimes:
     ar:
+      vat_refund: "Reintegro de IVA"
       title:
         "1": "Factura A"
         "2": "Nota de Débito A"


### PR DESCRIPTION
<img width="1093" height="794" alt="Screenshot 2026-06-22 at 12 30 52" src="https://github.com/user-attachments/assets/c03e105b-0149-4afe-be7e-d01ee218bf4f" />

Argentina type T invoices apply to tourism. In this case the tax is not paid but instead refunded through a reintegro.
