### PR TITLE
feat: derive document <title> from the document (2a) [APP-493]

### DIFF
--- a/components/bill/title.go
+++ b/components/bill/title.go
@@ -1,0 +1,36 @@
+package bill
+
+import (
+	"context"
+	"strings"
+
+	"github.com/invopop/ctxi18n/i18n"
+	"github.com/invopop/gobl.html/internal"
+)
+
+// DocumentTitle returns the localized document-type label plus series+code, e.g. "Invoice SAMPLE-001".
+func DocumentTitle(ctx context.Context, doc internal.Document) string {
+	label := untdidTitleLabel(ctx, doc)
+	if label == "" {
+		label = invoiceTitleLabel(ctx, doc)
+	}
+	code := doc.GetSeries().Join(doc.GetCode()).String()
+	return strings.TrimSpace(label + " " + code)
+}
+
+// invoiceTitleLabel resolves the generic invoice-type label, or "" if untranslated.
+func invoiceTitleLabel(ctx context.Context, doc internal.Document) string {
+	var key string
+	switch {
+	case isSimplifiedInvoice(doc):
+		key = "billing.invoice.title.standard-simplified"
+	case adjustmentMode(ctx, doc):
+		key = "billing.invoice.title.adjustment"
+	default:
+		key = "billing.invoice.title." + doc.GetType().String()
+	}
+	if label := i18n.T(ctx, key); !strings.HasPrefix(label, "!") {
+		return label
+	}
+	return ""
+}

--- a/components/envelope.templ
+++ b/components/envelope.templ
@@ -20,7 +20,7 @@ import (
 templ Envelope(env *gobl.Envelope) {
 	<html data-theme="light" if isRTL(ctx) { dir="rtl" }>
 		<head>
-			<title>GOBL HTML Generator</title>
+			<title>{ documentTitle(ctx, env) }</title>
 			<meta charset="utf-8"/>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 			<link rel="preconnect" href="https://fonts.googleapis.com"/>

--- a/components/envelope_templ.go
+++ b/components/envelope_templ.go
@@ -56,7 +56,20 @@ func Envelope(env *gobl.Envelope) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "><head><title>GOBL HTML Generator</title><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><link rel=\"preconnect\" href=\"https://fonts.googleapis.com\"><link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin><link href=\"https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap\" rel=\"stylesheet\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "><head><title>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var2 string
+		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(documentTitle(ctx, env))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/envelope.templ`, Line: 23, Col: 35}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</title><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><link rel=\"preconnect\" href=\"https://fonts.googleapis.com\"><link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin><link href=\"https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap\" rel=\"stylesheet\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -76,17 +89,17 @@ func Envelope(env *gobl.Envelope) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</head><body")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</head><body")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if applyLetterLayout(ctx) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, " class=\"letter\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " class=\"letter\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "><article class=\"envelope\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "><article class=\"envelope\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -130,7 +143,7 @@ func Envelope(env *gobl.Envelope) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		default:
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<p>Unknown document type</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<p>Unknown document type</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -139,7 +152,7 @@ func Envelope(env *gobl.Envelope) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</article></body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</article></body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/components/title.go
+++ b/components/title.go
@@ -1,0 +1,22 @@
+package components
+
+import (
+	"context"
+
+	"github.com/invopop/ctxi18n/i18n"
+	"github.com/invopop/gobl"
+	"github.com/invopop/gobl.html/components/bill"
+	"github.com/invopop/gobl.html/internal"
+	gbill "github.com/invopop/gobl/bill"
+)
+
+// documentTitle resolves the HTML <title> for an envelope: the document title for bills, else "Document".
+func documentTitle(ctx context.Context, env *gobl.Envelope) string {
+	switch doc := env.Extract().(type) {
+	case *gbill.Invoice, *gbill.Payment, *gbill.Delivery, *gbill.Order:
+		if title := bill.DocumentTitle(ctx, internal.DocumentFor(doc)); title != "" {
+			return title
+		}
+	}
+	return i18n.T(ctx, "billing.invoice.title.other")
+}

--- a/examples/out/ar-arca-invoice-logo.html
+++ b/examples/out/ar-arca-invoice-logo.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice 1-00000123
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/ar-arca-invoice.html
+++ b/examples/out/ar-arca-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice 1-00000123
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/ar-arca-liquido-producto.html
+++ b/examples/out/ar-arca-liquido-producto.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice 1-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/ar-arca-t-invoice-included.html
+++ b/examples/out/ar-arca-t-invoice-included.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice 1-00000002
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/ar-arca-t-invoice.html
+++ b/examples/out/ar-arca-t-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice 1-00000001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/co-dian-invoice.html
+++ b/examples/out/co-dian-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SETT-1041282
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/de-choruspro-invoice.html
+++ b/examples/out/de-choruspro-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/de-invoice.html
+++ b/examples/out/de-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-party.html
+++ b/examples/out/es-party.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Document
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-ticketbai-credit-note.adjustment.es.html
+++ b/examples/out/es-ticketbai-credit-note.adjustment.es.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Factura rectificativa FR-012
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-ticketbai-credit-note.html
+++ b/examples/out/es-ticketbai-credit-note.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Credit note FR-012
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-ticketbai-invoice.html
+++ b/examples/out/es-ticketbai-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-credit-note.adjustment.es.html
+++ b/examples/out/es-verifactu-credit-note.adjustment.es.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Factura rectificativa CN-0131232328387092873491782093478910237840917283904710923874
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-invoice-breakdown.html
+++ b/examples/out/es-verifactu-invoice-breakdown.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-invoice-delivery.html
+++ b/examples/out/es-verifactu-invoice-delivery.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-invoice-env.html
+++ b/examples/out/es-verifactu-invoice-env.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-invoice-freelance.html
+++ b/examples/out/es-verifactu-invoice-freelance.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-invoice-full.html
+++ b/examples/out/es-verifactu-invoice-full.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FAKE20220001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-invoice-limited-company.html
+++ b/examples/out/es-verifactu-invoice-limited-company.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FAKE20220001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-invoice-simplified.html
+++ b/examples/out/es-verifactu-invoice-simplified.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Simplified invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-invoice-tax-included.html
+++ b/examples/out/es-verifactu-invoice-tax-included.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FAKE20220001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-invoice-tax-surcharge.html
+++ b/examples/out/es-verifactu-invoice-tax-surcharge.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-invoice-usd.html
+++ b/examples/out/es-verifactu-invoice-usd.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice EXPORT-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-invoice.adjustment.html
+++ b/examples/out/es-verifactu-invoice.adjustment.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FAKE20220001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-invoice.html
+++ b/examples/out/es-verifactu-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/es-verifactu-receipt-with-tax.html
+++ b/examples/out/es-verifactu-receipt-with-tax.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      RCT-0001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/fr-choruspro-invoice.html
+++ b/examples/out/fr-choruspro-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/fr-ctc-credit-note.html
+++ b/examples/out/fr-ctc-credit-note.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Credit note AV-2024-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/fr-ctc-invoice-advance.html
+++ b/examples/out/fr-ctc-invoice-advance.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FAC-2024-AV-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/fr-ctc-invoice-b2b.html
+++ b/examples/out/fr-ctc-invoice-b2b.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FAC-2024-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/fr-ctc-invoice-b2bint.html
+++ b/examples/out/fr-ctc-invoice-b2bint.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FAC-2024-INT-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/fr-facturx-invoice.html
+++ b/examples/out/fr-facturx-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/fr-invoice-delivery.html
+++ b/examples/out/fr-invoice-delivery.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/fr-invoice.html
+++ b/examples/out/fr-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/gr-mydata-invoice.html
+++ b/examples/out/gr-mydata-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice GRT-082
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/gr-mydata-other-rents-income.html
+++ b/examples/out/gr-mydata-other-rents-income.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Document GRT-082
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/invoice-es-reverse-charge.html
+++ b/examples/out/invoice-es-reverse-charge.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-X-002
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/it-sdi-invoice-hotel-b2c.html
+++ b/examples/out/it-sdi-invoice-hotel-b2c.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-002
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/it-sdi-invoice-purchase-code.html
+++ b/examples/out/it-sdi-invoice-purchase-code.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-002
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/mx-sat-invoice-acuentaterceros.html
+++ b/examples/out/mx-sat-invoice-acuentaterceros.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice LMC-002
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/mx-sat-invoice-food-voucher.html
+++ b/examples/out/mx-sat-invoice-food-voucher.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice IN2024-0001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/mx-sat-invoice-fuel-balance.html
+++ b/examples/out/mx-sat-invoice-fuel-balance.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice IN2024-0003
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/mx-sat-invoice-ieps.html
+++ b/examples/out/mx-sat-invoice-ieps.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice TEST-00001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/mx-sat-invoice.html
+++ b/examples/out/mx-sat-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice LMC-0010
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/payment-multi-method.html
+++ b/examples/out/payment-multi-method.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      RCT-0002
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pl-ksef-invoice.html
+++ b/examples/out/pl-ksef-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SAMPLE-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-delivery-full.html
+++ b/examples/out/pt-at-delivery-full.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      GR SERIES-A-1
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-delivery-non-valued.html
+++ b/examples/out/pt-at-delivery-non-valued.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      GR DEV-10-2
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-delivery.html
+++ b/examples/out/pt-at-delivery.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      GR DEV-10-2
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-invoice-exempt.html
+++ b/examples/out/pt-at-invoice-exempt.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FT IXTEST-01/27
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-invoice-manual.html
+++ b/examples/out/pt-at-invoice-manual.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FT IXTEST-01/27
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-invoice-multipage.html
+++ b/examples/out/pt-at-invoice-multipage.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FT IXTEST-01/27
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-invoice-simplified.html
+++ b/examples/out/pt-at-invoice-simplified.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Simplified invoice FS IXTEST-01/34
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-invoice.sandbox.html
+++ b/examples/out/pt-at-invoice.sandbox.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FT IXTEST-01/27
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-invoice.void.html
+++ b/examples/out/pt-at-invoice.void.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FT IXTEST-01/27
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-order-full.html
+++ b/examples/out/pt-at-order-full.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      NE SERIES-A-123
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-order.html
+++ b/examples/out/pt-at-order.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      NE SERIES-A-1
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-receipt-full.html
+++ b/examples/out/pt-at-receipt-full.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      RG DEV-05-4
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-receipt-multi-method.html
+++ b/examples/out/pt-at-receipt-multi-method.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      RG SAMPLE-2
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-receipt-partial.html
+++ b/examples/out/pt-at-receipt-partial.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      RG SAMPLE-1
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/pt-at-receipt.html
+++ b/examples/out/pt-at-receipt.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      RG SAMPLE-1
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/sa-invoice-simplified.html
+++ b/examples/out/sa-invoice-simplified.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Simplified invoice 1765973
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/us-invoice-line-periods.html
+++ b/examples/out/us-invoice-line-periods.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice SUB-2024-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/us-invoice-seller.html
+++ b/examples/out/us-invoice-seller.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FAKE-0001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/us-invoice.html
+++ b/examples/out/us-invoice.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice FAKE-0001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/out/zw-invoice-usd.html
+++ b/examples/out/zw-invoice-usd.html
@@ -1,7 +1,7 @@
 <html data-theme="light">
   <head>
     <title>
-      GOBL HTML Generator
+      Invoice LOCAL-001
     </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Linear: [APP-493](https://linear.app/invopop/issue/APP-493/improve-pdf-title)

## Problem
The HTML `<title>` was hardcoded `GOBL HTML Generator` for every document (`components/envelope.templ`). Since Prince derives the PDF `/Title` from the HTML `<title>`, every generated PDF also got that generic metadata title — which shows in browser tabs / Document Properties when invoices are shared with customers.

## Change ("2a")
Set `<title>` to the **localized document-type name + `series`+`code`**, e.g. `Invoice SAMPLE-001`, `Credit note CN-012`, `Factura rectificativa FR-012`.

- New `bill.DocumentTitle(ctx, doc)` resolves the type label the same way as the printed heading for the common cases: the **EN 16931 UNTDID** document-type label when present, else the generic `billing.invoice.title.<type>` label (incl. the `simplified` and `adjustment` cases), then appends `series.Join(code)`.
- `components.documentTitle(ctx, env)` wires it into the `<head>`; non-billing docs get a neutral fallback.
- Regime-specific headings (AR/CO/PT/GR) are **not** mirrored — those documents fall back to the generic label + code (still meaningful). Extending to full regime parity ("2b") is a follow-up if needed.

Fixes **both** the HTML preview tab and the PDF `/Title` in one place.

## Verified
Re-rendered all examples (`go test . -run TestGOBLRenderExamples -update`) and confirmed titles across regimes:
- `fr-invoice` / `de-invoice` / `pl-ksef` / `it-sdi` / `mx-sat` / `es-verifactu-invoice` → `Invoice <code>`
- `fr-ctc-credit-note` / `es-ticketbai-credit-note` → `Credit note <code>`
- simplified → `Simplified invoice <code>`; adjustment (localized) → `Factura rectificativa <code>`
- AR/CO/GR/PT → generic label + code (as designed)

`go build ./...` ✓, `go test ./...` ✓. (Generated `envelope_templ.go` regenerated with `templ`; example `examples/out` left as-is — regenerate with `-update` when desired.)

## Follow-up (pdf.go)
Once released, bump the `gobl.html` dependency in `pdf.go` and **drop the interim `Metadata.Title` override** (PR invopop/pdf.go#105) so Prince uses this `<title>` directly. That makes this the single source of truth and fixes the HTML tab too.