### PR TITLE
Respect currency layout options in exchange rates and other fixed-currency amounts

### DIFF
--- a/components/t/i18n.templ
+++ b/components/t/i18n.templ
@@ -88,24 +88,14 @@ func LocalizeMoney(ctx context.Context, a num.Amount) string {
 }
 
 // LocalizeCurrency will produce a localized string representation of the given
-// amount for the provided currency. Any currency layout overrides defined in
-// the rendering options, such as the currency template or separators, take
-// precedence over the currency's own defaults.
+// amount for the provided currency. The layout comes from the document's
+// number formatter so that all amounts are presented consistently, with only
+// the unit symbol taken from the provided currency. When no formatter is
+// available in the context, the currency's own defaults are used.
 func LocalizeCurrency(ctx context.Context, a num.Amount, cur currency.Code, opts ...currency.FormatOption) string {
 	f := cur.Def().Formatter(opts...)
-	if o := internal.Options(ctx); o != nil {
-		if o.CurrencyTemplate != "" {
-			f.Template = o.CurrencyTemplate
-		}
-		if o.ThousandsSeparator != "" {
-			f.ThousandsSeparator = o.ThousandsSeparator
-		}
-		if o.DecimalMark != "" {
-			f.DecimalMark = o.DecimalMark
-		}
-		if o.NegativeTemplate != "" {
-			f.NegativeTemplate = o.NegativeTemplate
-		}
+	if o := internal.Options(ctx); o != nil && o.NumFormatter != nil {
+		f = o.NumFormatter.WithUnit(f.Unit)
 	}
 	return f.Amount(a)
 }

--- a/components/t/i18n.templ
+++ b/components/t/i18n.templ
@@ -89,9 +89,11 @@ func LocalizeMoney(ctx context.Context, a num.Amount) string {
 
 // LocalizeCurrency will produce a localized string representation of the given
 // amount for the provided currency. The layout comes from the document's
-// number formatter so that all amounts are presented consistently, with only
-// the unit symbol taken from the provided currency. When no formatter is
-// available in the context, the currency's own defaults are used.
+// number formatter so that all amounts are presented consistently: only the
+// unit symbol, as prepared by the format options, is taken from the provided
+// currency, and any other effect of the format options is superseded by the
+// document formatter. When no formatter is available in the context, the
+// currency's own defaults and format options are used as-is.
 func LocalizeCurrency(ctx context.Context, a num.Amount, cur currency.Code, opts ...currency.FormatOption) string {
 	f := cur.Def().Formatter(opts...)
 	if o := internal.Options(ctx); o != nil && o.NumFormatter != nil {

--- a/components/t/i18n.templ
+++ b/components/t/i18n.templ
@@ -88,8 +88,24 @@ func LocalizeMoney(ctx context.Context, a num.Amount) string {
 }
 
 // LocalizeCurrency will produce a localized string representation of the given
-// amount for the provided currency.
-func LocalizeCurrency(_ context.Context, a num.Amount, cur currency.Code, opts ...currency.FormatOption) string {
+// amount for the provided currency. Any currency layout overrides defined in
+// the rendering options, such as the currency template or separators, take
+// precedence over the currency's own defaults.
+func LocalizeCurrency(ctx context.Context, a num.Amount, cur currency.Code, opts ...currency.FormatOption) string {
 	f := cur.Def().Formatter(opts...)
+	if o := internal.Options(ctx); o != nil {
+		if o.CurrencyTemplate != "" {
+			f.Template = o.CurrencyTemplate
+		}
+		if o.ThousandsSeparator != "" {
+			f.ThousandsSeparator = o.ThousandsSeparator
+		}
+		if o.DecimalMark != "" {
+			f.DecimalMark = o.DecimalMark
+		}
+		if o.NegativeTemplate != "" {
+			f.NegativeTemplate = o.NegativeTemplate
+		}
+	}
 	return f.Amount(a)
 }

--- a/components/t/i18n.templ
+++ b/components/t/i18n.templ
@@ -88,12 +88,7 @@ func LocalizeMoney(ctx context.Context, a num.Amount) string {
 }
 
 // LocalizeCurrency will produce a localized string representation of the given
-// amount for the provided currency. The layout comes from the document's
-// number formatter so that all amounts are presented consistently: only the
-// unit symbol, as prepared by the format options, is taken from the provided
-// currency, and any other effect of the format options is superseded by the
-// document formatter. When no formatter is available in the context, the
-// currency's own defaults and format options are used as-is.
+// amount for the provided currency.
 func LocalizeCurrency(ctx context.Context, a num.Amount, cur currency.Code, opts ...currency.FormatOption) string {
 	f := cur.Def().Formatter(opts...)
 	if o := internal.Options(ctx); o != nil && o.NumFormatter != nil {

--- a/components/t/i18n_templ.go
+++ b/components/t/i18n_templ.go
@@ -302,9 +302,11 @@ func LocalizeMoney(ctx context.Context, a num.Amount) string {
 
 // LocalizeCurrency will produce a localized string representation of the given
 // amount for the provided currency. The layout comes from the document's
-// number formatter so that all amounts are presented consistently, with only
-// the unit symbol taken from the provided currency. When no formatter is
-// available in the context, the currency's own defaults are used.
+// number formatter so that all amounts are presented consistently: only the
+// unit symbol, as prepared by the format options, is taken from the provided
+// currency, and any other effect of the format options is superseded by the
+// document formatter. When no formatter is available in the context, the
+// currency's own defaults and format options are used as-is.
 func LocalizeCurrency(ctx context.Context, a num.Amount, cur currency.Code, opts ...currency.FormatOption) string {
 	f := cur.Def().Formatter(opts...)
 	if o := internal.Options(ctx); o != nil && o.NumFormatter != nil {

--- a/components/t/i18n_templ.go
+++ b/components/t/i18n_templ.go
@@ -301,24 +301,14 @@ func LocalizeMoney(ctx context.Context, a num.Amount) string {
 }
 
 // LocalizeCurrency will produce a localized string representation of the given
-// amount for the provided currency. Any currency layout overrides defined in
-// the rendering options, such as the currency template or separators, take
-// precedence over the currency's own defaults.
+// amount for the provided currency. The layout comes from the document's
+// number formatter so that all amounts are presented consistently, with only
+// the unit symbol taken from the provided currency. When no formatter is
+// available in the context, the currency's own defaults are used.
 func LocalizeCurrency(ctx context.Context, a num.Amount, cur currency.Code, opts ...currency.FormatOption) string {
 	f := cur.Def().Formatter(opts...)
-	if o := internal.Options(ctx); o != nil {
-		if o.CurrencyTemplate != "" {
-			f.Template = o.CurrencyTemplate
-		}
-		if o.ThousandsSeparator != "" {
-			f.ThousandsSeparator = o.ThousandsSeparator
-		}
-		if o.DecimalMark != "" {
-			f.DecimalMark = o.DecimalMark
-		}
-		if o.NegativeTemplate != "" {
-			f.NegativeTemplate = o.NegativeTemplate
-		}
+	if o := internal.Options(ctx); o != nil && o.NumFormatter != nil {
+		f = o.NumFormatter.WithUnit(f.Unit)
 	}
 	return f.Amount(a)
 }

--- a/components/t/i18n_templ.go
+++ b/components/t/i18n_templ.go
@@ -301,9 +301,25 @@ func LocalizeMoney(ctx context.Context, a num.Amount) string {
 }
 
 // LocalizeCurrency will produce a localized string representation of the given
-// amount for the provided currency.
-func LocalizeCurrency(_ context.Context, a num.Amount, cur currency.Code, opts ...currency.FormatOption) string {
+// amount for the provided currency. Any currency layout overrides defined in
+// the rendering options, such as the currency template or separators, take
+// precedence over the currency's own defaults.
+func LocalizeCurrency(ctx context.Context, a num.Amount, cur currency.Code, opts ...currency.FormatOption) string {
 	f := cur.Def().Formatter(opts...)
+	if o := internal.Options(ctx); o != nil {
+		if o.CurrencyTemplate != "" {
+			f.Template = o.CurrencyTemplate
+		}
+		if o.ThousandsSeparator != "" {
+			f.ThousandsSeparator = o.ThousandsSeparator
+		}
+		if o.DecimalMark != "" {
+			f.DecimalMark = o.DecimalMark
+		}
+		if o.NegativeTemplate != "" {
+			f.NegativeTemplate = o.NegativeTemplate
+		}
+	}
 	return f.Amount(a)
 }
 

--- a/components/t/i18n_test.go
+++ b/components/t/i18n_test.go
@@ -16,59 +16,48 @@ import (
 func TestLocalizeCurrency(t *testing.T) {
 	amount := num.MakeAmount(123456, 2)
 
-	tests := []struct {
-		name     string
-		opts     *internal.Opts
-		expected string
-	}{
-		{
-			name:     "currency defaults",
-			opts:     &internal.Opts{},
-			expected: "€1.234,56",
-		},
-		{
-			name: "custom currency template",
-			opts: &internal.Opts{
-				CurrencyTemplate: "%n %u",
-			},
-			expected: "1.234,56 €",
-		},
-		{
-			name: "custom separators",
-			opts: &internal.Opts{
-				ThousandsSeparator: ",",
-				DecimalMark:        ".",
-			},
-			expected: "€1,234.56",
-		},
-		{
-			name: "custom negative template",
-			opts: &internal.Opts{
-				NegativeTemplate: "(%n%u)",
-			},
-			expected: "€1.234,56",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := internal.WithOptions(context.Background(), tc.opts)
-			got := calT.LocalizeCurrency(ctx, amount, currency.EUR)
-			assert.Equal(t, tc.expected, got)
-		})
-	}
-
-	t.Run("negative amount with custom template", func(t *testing.T) {
-		ctx := internal.WithOptions(context.Background(), &internal.Opts{
-			NegativeTemplate: "(%u%n)",
-		})
-		got := calT.LocalizeCurrency(ctx, amount.Negate(), currency.EUR)
-		assert.Equal(t, "(€1.234,56)", got)
-	})
-
 	t.Run("no options in context", func(t *testing.T) {
 		got := calT.LocalizeCurrency(context.Background(), amount, currency.EUR)
 		assert.Equal(t, "€1.234,56", got)
+	})
+
+	t.Run("no formatter in options", func(t *testing.T) {
+		ctx := internal.WithOptions(context.Background(), &internal.Opts{})
+		got := calT.LocalizeCurrency(ctx, amount, currency.EUR)
+		assert.Equal(t, "€1.234,56", got)
+	})
+
+	t.Run("uses document layout with target currency symbol", func(t *testing.T) {
+		// A GBP document formatted with a custom layout, e.g. "3,99 £",
+		// converting an amount to EUR should keep the same layout: "1 234,56 €".
+		nf := currency.GBP.Def().Formatter()
+		nf.Template = "%n %u"
+		nf.ThousandsSeparator = " "
+		nf.DecimalMark = ","
+		ctx := internal.WithOptions(context.Background(), &internal.Opts{
+			NumFormatter: &nf,
+		})
+		got := calT.LocalizeCurrency(ctx, amount, currency.EUR)
+		assert.Equal(t, "1 234,56 €", got)
+	})
+
+	t.Run("negative amounts follow the document layout", func(t *testing.T) {
+		nf := currency.GBP.Def().Formatter()
+		nf.NegativeTemplate = "(%u%n)"
+		ctx := internal.WithOptions(context.Background(), &internal.Opts{
+			NumFormatter: &nf,
+		})
+		got := calT.LocalizeCurrency(ctx, amount.Negate(), currency.EUR)
+		assert.Equal(t, "(€1,234.56)", got)
+	})
+
+	t.Run("disambiguate symbol is preserved", func(t *testing.T) {
+		nf := currency.EUR.Def().Formatter()
+		ctx := internal.WithOptions(context.Background(), &internal.Opts{
+			NumFormatter: &nf,
+		})
+		got := calT.LocalizeCurrency(ctx, amount, currency.USD, currency.WithDisambiguateSymbol())
+		assert.Equal(t, "US$1.234,56", got)
 	})
 }
 

--- a/components/t/i18n_test.go
+++ b/components/t/i18n_test.go
@@ -8,9 +8,69 @@ import (
 	calT "github.com/invopop/gobl.html/components/t"
 	"github.com/invopop/gobl.html/internal"
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestLocalizeCurrency(t *testing.T) {
+	amount := num.MakeAmount(123456, 2)
+
+	tests := []struct {
+		name     string
+		opts     *internal.Opts
+		expected string
+	}{
+		{
+			name:     "currency defaults",
+			opts:     &internal.Opts{},
+			expected: "€1.234,56",
+		},
+		{
+			name: "custom currency template",
+			opts: &internal.Opts{
+				CurrencyTemplate: "%n %u",
+			},
+			expected: "1.234,56 €",
+		},
+		{
+			name: "custom separators",
+			opts: &internal.Opts{
+				ThousandsSeparator: ",",
+				DecimalMark:        ".",
+			},
+			expected: "€1,234.56",
+		},
+		{
+			name: "custom negative template",
+			opts: &internal.Opts{
+				NegativeTemplate: "(%n%u)",
+			},
+			expected: "€1.234,56",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := internal.WithOptions(context.Background(), tc.opts)
+			got := calT.LocalizeCurrency(ctx, amount, currency.EUR)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+
+	t.Run("negative amount with custom template", func(t *testing.T) {
+		ctx := internal.WithOptions(context.Background(), &internal.Opts{
+			NegativeTemplate: "(%u%n)",
+		})
+		got := calT.LocalizeCurrency(ctx, amount.Negate(), currency.EUR)
+		assert.Equal(t, "(€1.234,56)", got)
+	})
+
+	t.Run("no options in context", func(t *testing.T) {
+		got := calT.LocalizeCurrency(context.Background(), amount, currency.EUR)
+		assert.Equal(t, "€1.234,56", got)
+	})
+}
 
 func TestLocalizeDateTime(t *testing.T) {
 	// 2026-03-25T12:34 – matches the co-dian-invoice example that has both

--- a/examples/out/es-verifactu-invoice-usd.html
+++ b/examples/out/es-verifactu-invoice-usd.html
@@ -167,7 +167,7 @@
                 <td class="price">
                   $100.00
                   <span class="alt-price">
-                    €90,00
+                    €90.00
                   </span>
                 </td>
                 <td class="discount">
@@ -281,7 +281,7 @@
                       Exchange to EUR (0.875967)
                     </th>
                     <td>
-                      €2.857,82
+                      €2,857.82
                     </td>
                   </tr>
                 </tbody>

--- a/examples/out/pt-at-invoice-exempt.html
+++ b/examples/out/pt-at-invoice-exempt.html
@@ -108,7 +108,7 @@
                     </span>
                   </div>
                   <div class="capital">
-                    Social capital: €2.000.000,00
+                    Social capital: 2 000 000,00 €
                   </div>
                 </div>
               </div>

--- a/goblhtml.go
+++ b/goblhtml.go
@@ -203,10 +203,18 @@ func Render(ctx context.Context, env *gobl.Envelope, opts ...Option) ([]byte, er
 			nf = d.GetCurrency().Def().Formatter()
 
 			if d.GetRegime().Country.Code() == l10n.PT {
-				// As required by the Portuguese tax law
-				nf.ThousandsSeparator = " "
-				nf.DecimalMark = ","
-				nf.Template = "%n %u"
+				// As required by the Portuguese tax law. Set as option
+				// overrides so that amounts in other currencies, such as
+				// exchange rate conversions, use the same layout.
+				if o.ThousandsSeparator == "" {
+					o.ThousandsSeparator = " "
+				}
+				if o.DecimalMark == "" {
+					o.DecimalMark = ","
+				}
+				if o.CurrencyTemplate == "" {
+					o.CurrencyTemplate = "%n %u"
+				}
 			}
 		}
 	}

--- a/goblhtml.go
+++ b/goblhtml.go
@@ -203,18 +203,10 @@ func Render(ctx context.Context, env *gobl.Envelope, opts ...Option) ([]byte, er
 			nf = d.GetCurrency().Def().Formatter()
 
 			if d.GetRegime().Country.Code() == l10n.PT {
-				// As required by the Portuguese tax law. Set as option
-				// overrides so that amounts in other currencies, such as
-				// exchange rate conversions, use the same layout.
-				if o.ThousandsSeparator == "" {
-					o.ThousandsSeparator = " "
-				}
-				if o.DecimalMark == "" {
-					o.DecimalMark = ","
-				}
-				if o.CurrencyTemplate == "" {
-					o.CurrencyTemplate = "%n %u"
-				}
+				// As required by the Portuguese tax law
+				nf.ThousandsSeparator = " "
+				nf.DecimalMark = ","
+				nf.Template = "%n %u"
 			}
 		}
 	}


### PR DESCRIPTION
## What

Amounts rendered in a specific currency — exchange rate conversions in the totals, payment records in other currencies, line substitutions, and registration capital notes — now follow the document's number formatting, with only the unit symbol taken from the target currency. Previously they always used the target currency's default layout, ignoring how the rest of the document was configured.

## Why

`LocalizeCurrency` ignored the rendering context entirely and built its formatter purely from the target currency's defaults. A client invoice in GBP rendered with a `%n %u` layout showed every amount as `3,99 £` — but the exchange rate row rendered `€4,69`, with the symbol on the wrong side and inconsistent with the rest of the document.

## How

`LocalizeCurrency` now takes the layout (template, separators, negative template, numeral system) from the document's number formatter in the rendering context and swaps in the target currency's symbol (including the disambiguate symbol for `LCD`). This works regardless of whether the layout came from the currency defaults, individual options like `WithCurrencyTemplate`, the Portuguese tax-law rules, or a full custom formatter via `WithNumFormatter`. When no formatter is present in the context, the currency's own defaults apply as before.

## Notes for reviewers

- This intentionally changes how converted amounts are formatted on documents whose main currency uses different separators: `examples/out/es-verifactu-invoice-usd.html` now shows the EUR conversion as `€2,857.82` (US-style separators, consistent with the `US$` amounts in the document) instead of `€2.857,82`. Mixing separator conventions within one document was ambiguous — the previous output used a comma as thousands separator on one row and as decimal mark on the next.
- Added `TestLocalizeCurrency` covering the fallback, layout inheritance, negative templates, and the disambiguate symbol.
- Verified with the client's scenario: with a `%n %u` / comma-decimal layout, totals render `3 262,48 $` and the exchange row `2 857,82 €` — via both individual options and `WithNumFormatter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)