### PR TITLE
feat(co): show official title for DIAN credit notes

### DIFF
--- a/components/regimes/co/co.go
+++ b/components/regimes/co/co.go
@@ -22,8 +22,11 @@ func titleKey(doc internal.Document) string {
 	if !ok {
 		return ""
 	}
-	if inv.Type == bill.InvoiceTypeStandard {
+	switch inv.Type {
+	case bill.InvoiceTypeStandard:
 		return "standard"
+	case bill.InvoiceTypeCreditNote:
+		return "credit-note"
 	}
 	return ""
 }

--- a/examples/out/co-dian-credit-note.html
+++ b/examples/out/co-dian-credit-note.html
@@ -95,7 +95,7 @@
               </div>
               <div class="title-group title-group-inline">
                 <h1 class="type">
-                  Credit note
+                  Electronic credit note
                 </h1>
                 <h2 class="code">
                   NCTT-1030111
@@ -387,7 +387,7 @@
             </div>
             <div class="title-group title-group-inline">
               <h1 class="type">
-                Credit note
+                Electronic credit note
               </h1>
               <h2 class="code">
                 NCTT-1030111

--- a/locales/en/app.yml
+++ b/locales/en/app.yml
@@ -272,6 +272,7 @@ en:
     co:
       title:
         standard: "Electronic sales invoice"
+        credit-note: "Electronic credit note"
     it:
       title:
         # AdE receipt document names ("documento commerciale"); corrections

--- a/locales/es/app.yml
+++ b/locales/es/app.yml
@@ -383,3 +383,4 @@ es:
     co:
       title:
         standard: "Factura electrónica de venta"
+        credit-note: "Nota de crédito electrónica"


### PR DESCRIPTION
## What

Colombian credit notes now render **"Nota de crédito electrónica"** (Spanish) / **"Electronic credit note"** (English) as the title above the document number, instead of the generic "Credit note".

## Why

Standard Colombian invoices already override the title with the official DIAN name ("Factura electrónica de venta"); credit notes should use their official name too.

## How

- `components/regimes/co/co.go`: `titleKey` now maps `bill.InvoiceTypeCreditNote` to a new `credit-note` key, alongside the existing `standard` case.
- `locales/en/app.yml` / `locales/es/app.yml`: added the `regimes.co.title.credit-note` translations (only these two locales define Colombian titles).
- `examples/out/co-dian-credit-note.html`: regenerated with `go test -run TestGOBLRenderExamples --update`.

No template changes were needed — `dian.templ` already routes any non-empty `titleKey` through the `regimes.co.title.*` translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)