### PR TITLE
Hide party identities without a key, type or label

### DIFF
--- a/components/org/party.templ
+++ b/components/org/party.templ
@@ -225,6 +225,8 @@ func showIdentity(ctx context.Context, ident *org.Identity) bool {
 		return true
 	}
 	if ident.Key != "" {
+		// ctxi18n returns "!(MISSING: <key>)" when no translation is
+		// defined, so a "!" prefix means the key has no label to show.
 		label := i18n.T(ctx, fmt.Sprintf(".identity_labels.%s", ident.Key))
 		return !strings.HasPrefix(label, "!")
 	}

--- a/components/org/party.templ
+++ b/components/org/party.templ
@@ -99,7 +99,7 @@ templ websites(websites []*org.Website) {
 templ identities(idents []*org.Identity) {
 	for _, ident := range idents {
 		if showIdentity(ctx, ident) {
-			<div class="identitiy">
+			<div class="identity">
 				@t.T(".identity", i18n.M{"label": identityLabel(ctx, ident), "code": ident.Code})
 			</div>
 		}

--- a/components/org/party.templ
+++ b/components/org/party.templ
@@ -98,9 +98,11 @@ templ websites(websites []*org.Website) {
 
 templ identities(idents []*org.Identity) {
 	for _, ident := range idents {
-		<div class="identitiy">
-			@t.T(".identity", i18n.M{"label": identityLabel(ctx, ident), "code": ident.Code})
-		</div>
+		if showIdentity(ctx, ident) {
+			<div class="identitiy">
+				@t.T(".identity", i18n.M{"label": identityLabel(ctx, ident), "code": ident.Code})
+			</div>
+		}
 	}
 }
 
@@ -216,6 +218,17 @@ func identityLabel(ctx context.Context, ident *org.Identity) string {
 		}
 	}
 	return i18n.T(ctx, ".identity_code")
+}
+
+func showIdentity(ctx context.Context, ident *org.Identity) bool {
+	if ident.Label != "" || ident.Type != "" {
+		return true
+	}
+	if ident.Key != "" {
+		label := i18n.T(ctx, fmt.Sprintf(".identity_labels.%s", ident.Key))
+		return !strings.HasPrefix(label, "!")
+	}
+	return false
 }
 
 func showTaxID(party *org.Party) bool {

--- a/components/org/party_templ.go
+++ b/components/org/party_templ.go
@@ -461,17 +461,19 @@ func identities(idents []*org.Identity) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		for _, ident := range idents {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"identitiy\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = t.T(".identity", i18n.M{"label": identityLabel(ctx, ident), "code": ident.Code}).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
+			if showIdentity(ctx, ident) {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"identitiy\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = t.T(".identity", i18n.M{"label": identityLabel(ctx, ident), "code": ident.Code}).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
 		}
 		return nil
@@ -532,7 +534,7 @@ func registration(reg *org.Registration) templ.Component {
 					var templ_7745c5c3_Var14 string
 					templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(reg.Office)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 116, Col: 18}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 118, Col: 18}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 					if templ_7745c5c3_Err != nil {
@@ -635,7 +637,7 @@ func registration(reg *org.Registration) templ.Component {
 					var templ_7745c5c3_Var15 string
 					templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(reg.Other)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 151, Col: 17}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 153, Col: 17}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 					if templ_7745c5c3_Err != nil {
@@ -705,7 +707,7 @@ func partyExtensions(party *org.Party) templ.Component {
 				var templ_7745c5c3_Var17 string
 				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(txt)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 168, Col: 9}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 170, Col: 9}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 				if templ_7745c5c3_Err != nil {
@@ -766,6 +768,17 @@ func identityLabel(ctx context.Context, ident *org.Identity) string {
 		}
 	}
 	return i18n.T(ctx, ".identity_code")
+}
+
+func showIdentity(ctx context.Context, ident *org.Identity) bool {
+	if ident.Label != "" || ident.Type != "" {
+		return true
+	}
+	if ident.Key != "" {
+		label := i18n.T(ctx, fmt.Sprintf(".identity_labels.%s", ident.Key))
+		return !strings.HasPrefix(label, "!")
+	}
+	return false
 }
 
 func showTaxID(party *org.Party) bool {

--- a/components/org/party_templ.go
+++ b/components/org/party_templ.go
@@ -462,7 +462,7 @@ func identities(idents []*org.Identity) templ.Component {
 		ctx = templ.ClearChildren(ctx)
 		for _, ident := range idents {
 			if showIdentity(ctx, ident) {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"identitiy\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"identity\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/components/org/party_templ.go
+++ b/components/org/party_templ.go
@@ -775,6 +775,8 @@ func showIdentity(ctx context.Context, ident *org.Identity) bool {
 		return true
 	}
 	if ident.Key != "" {
+		// ctxi18n returns "!(MISSING: <key>)" when no translation is
+		// defined, so a "!" prefix means the key has no label to show.
 		label := i18n.T(ctx, fmt.Sprintf(".identity_labels.%s", ident.Key))
 		return !strings.HasPrefix(label, "!")
 	}

--- a/examples/out/ar-arca-t-invoice-included.html
+++ b/examples/out/ar-arca-t-invoice-included.html
@@ -118,9 +118,6 @@
                       123 Main St, New York, NY (United States of America)
                     </span>
                   </div>
-                  <div class="identitiy">
-                    Identity code: AB123456
-                  </div>
                   <div class="arca-vat-legend">
                     CLIENTE DEL EXTERIOR
                   </div>

--- a/examples/out/ar-arca-t-invoice.html
+++ b/examples/out/ar-arca-t-invoice.html
@@ -118,9 +118,6 @@
                       123 Main St, New York, NY (United States of America)
                     </span>
                   </div>
-                  <div class="identitiy">
-                    Identity code: AB123456
-                  </div>
                   <div class="arca-vat-legend">
                     CLIENTE DEL EXTERIOR
                   </div>

--- a/examples/out/de-choruspro-invoice.html
+++ b/examples/out/de-choruspro-invoice.html
@@ -124,7 +124,7 @@
                   <div class="tax-id">
                     TVA: (FR) 44732829320
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     SIRET: 73282932012345
                   </div>
                 </div>

--- a/examples/out/es-party.html
+++ b/examples/out/es-party.html
@@ -45,7 +45,7 @@
         <div class="tax-id">
           NIF: (ES) B28774008
         </div>
-        <div class="identitiy">
+        <div class="identity">
           LEI: 1010101010
         </div>
       </div>

--- a/examples/out/es-party.html
+++ b/examples/out/es-party.html
@@ -48,9 +48,6 @@
         <div class="identitiy">
           LEI: 1010101010
         </div>
-        <div class="identitiy">
-          Identity code: ABC1234
-        </div>
       </div>
       <footer class="screen">
         <div class="gobl-logo">

--- a/examples/out/es-verifactu-invoice-full.html
+++ b/examples/out/es-verifactu-invoice-full.html
@@ -120,9 +120,6 @@
                   <div class="identitiy">
                     LEI: 1010101010
                   </div>
-                  <div class="identitiy">
-                    Identity code: ABC1234
-                  </div>
                 </div>
               </div>
             </section>

--- a/examples/out/es-verifactu-invoice-full.html
+++ b/examples/out/es-verifactu-invoice-full.html
@@ -117,7 +117,7 @@
                   <div class="tax-id">
                     NIF: (ES) B28774008
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     LEI: 1010101010
                   </div>
                 </div>
@@ -146,7 +146,7 @@
                   <div class="tax-id">
                     NIF: (ES) B33105842
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     Código de Cliente: 123456789ABC
                   </div>
                 </div>

--- a/examples/out/es-verifactu-invoice.adjustment.html
+++ b/examples/out/es-verifactu-invoice.adjustment.html
@@ -120,9 +120,6 @@
                   <div class="identitiy">
                     LEI: 1010101010
                   </div>
-                  <div class="identitiy">
-                    Identity code: ABC1234
-                  </div>
                 </div>
               </div>
             </section>

--- a/examples/out/es-verifactu-invoice.adjustment.html
+++ b/examples/out/es-verifactu-invoice.adjustment.html
@@ -117,7 +117,7 @@
                   <div class="tax-id">
                     NIF: (ES) B28774008
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     LEI: 1010101010
                   </div>
                 </div>
@@ -146,7 +146,7 @@
                   <div class="tax-id">
                     NIF: (ES) B33105842
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     Código de Cliente: 123456789ABC
                   </div>
                 </div>

--- a/examples/out/fr-choruspro-invoice.html
+++ b/examples/out/fr-choruspro-invoice.html
@@ -104,7 +104,7 @@
                   <div class="tax-id">
                     TVA: (FR) 44732829320
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     SIRET: 73282932012345
                   </div>
                 </div>
@@ -130,7 +130,7 @@
                   <div class="tax-id">
                     TVA: (FR) 39356000000
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     SIRET: 35600000012345
                   </div>
                 </div>

--- a/examples/out/fr-ctc-credit-note.html
+++ b/examples/out/fr-ctc-credit-note.html
@@ -112,7 +112,7 @@
                   <div class="tax-id">
                     TVA: (FR) 44732829320
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     SIREN: 732829320
                   </div>
                 </div>
@@ -138,7 +138,7 @@
                   <div class="tax-id">
                     TVA: (FR) 39356000000
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     SIREN: 356000000
                   </div>
                 </div>

--- a/examples/out/fr-ctc-invoice-advance.html
+++ b/examples/out/fr-ctc-invoice-advance.html
@@ -101,7 +101,7 @@
                   <div class="tax-id">
                     TVA: (FR) 44732829320
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     SIREN: 732829320
                   </div>
                 </div>
@@ -127,7 +127,7 @@
                   <div class="tax-id">
                     TVA: (FR) 39356000000
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     SIREN: 356000000
                   </div>
                 </div>

--- a/examples/out/fr-ctc-invoice-b2b.html
+++ b/examples/out/fr-ctc-invoice-b2b.html
@@ -112,7 +112,7 @@
                   <div class="tax-id">
                     TVA: (FR) 44732829320
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     SIREN: 732829320
                   </div>
                 </div>
@@ -141,7 +141,7 @@
                   <div class="tax-id">
                     TVA: (FR) 39356000000
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     SIREN: 356000000
                   </div>
                 </div>

--- a/examples/out/fr-ctc-invoice-b2bint.html
+++ b/examples/out/fr-ctc-invoice-b2bint.html
@@ -101,7 +101,7 @@
                   <div class="tax-id">
                     TVA: (FR) 44732829320
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     SIREN: 732829320
                   </div>
                 </div>

--- a/examples/out/fr-ctc-invoice-b2bint.html
+++ b/examples/out/fr-ctc-invoice-b2bint.html
@@ -127,9 +127,6 @@
                   <div class="tax-id">
                     TIN: (DE) 111111125
                   </div>
-                  <div class="identitiy">
-                    Identity code: DE111111125
-                  </div>
                 </div>
               </div>
             </section>

--- a/examples/out/it-sdi-invoice-hotel-b2c.html
+++ b/examples/out/it-sdi-invoice-hotel-b2c.html
@@ -121,7 +121,7 @@
                       Via dei Mille 23, Firenze, FI, 00100 (Italy)
                     </span>
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     Codice fiscale: RSSGNN60R30H501U
                   </div>
                 </div>

--- a/examples/out/it-sdi-invoice-purchase-code.html
+++ b/examples/out/it-sdi-invoice-purchase-code.html
@@ -154,7 +154,7 @@
                       Via dei Mille 23, Firenze, FI, 00100 (Italy)
                     </span>
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     Codice fiscale: RSSGNN60R30H501U
                   </div>
                 </div>

--- a/examples/out/us-invoice-seller.html
+++ b/examples/out/us-invoice-seller.html
@@ -113,7 +113,7 @@
                   <div class="emails">
                     Email: sam@example.com
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     Código de Cliente: 123456789ABC
                   </div>
                 </div>

--- a/examples/out/us-invoice.html
+++ b/examples/out/us-invoice.html
@@ -113,7 +113,7 @@
                   <div class="emails">
                     Email: sam@example.com
                   </div>
-                  <div class="identitiy">
+                  <div class="identity">
                     Código de Cliente: 123456789ABC
                   </div>
                 </div>


### PR DESCRIPTION
## What

- Party identities are now only rendered when they have something meaningful to label them with: a `label`, a `type`, or a `key` that has a matching `.identity_labels.*` translation. Identities with only a bare code are no longer displayed.
- Fixed the misspelled `identitiy` CSS class on the identity block, renaming it to `identity` (flagged in review; the typo predates this PR).

## Why

Previously every identity in a party was rendered unconditionally, so identities carrying only a code appeared with the generic "Identity code: XXX" fallback label, which adds noise without telling the reader what the code actually is.

## Notes for reviewers

- New `showIdentity` helper in `components/org/party.templ` gates rendering; identities with an untranslated key are hidden too, so the generic "Identity code" fallback in `identityLabel` is now effectively unreachable (kept as a safety net).
- Example outputs regenerated with `go test . -update`. Two kinds of changes:
  - 6 files lose exactly one bare `Identity code: …` block (from the visibility change); labeled identities (e.g. LEI) are unaffected.
  - 14 files have `identitiy` → `identity` class substitutions (from the typo fix); nothing in this repo selects on the old class name, but downstream consumers with custom CSS targeting `.identitiy` would need to update.
- Generated code produced with templ v0.3.1001 (the version pinned in go.mod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)