### PR TITLE
Render credit transfer clearing codes

### DIFF
--- a/components/bill/payment_details.templ
+++ b/components/bill/payment_details.templ
@@ -169,6 +169,11 @@ templ paymentCreditTransferRow(ct *pay.CreditTransfer) {
 				@t.T(".account_number", i18n.M{"num": ct.Number})
 			</div>
 		}
+		if ct.Clearing != "" {
+			<div class="clearing nowrap">
+				@t.T(".clearing", i18n.M{"code": ct.Clearing})
+			</div>
+		}
 		if ct.BIC != "" {
 			<div class="bic nowrap">
 				@t.T(".bic", i18n.M{"bic": ct.BIC})

--- a/components/bill/payment_details_templ.go
+++ b/components/bill/payment_details_templ.go
@@ -573,12 +573,12 @@ func paymentCreditTransferRow(ct *pay.CreditTransfer) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		if ct.BIC != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<div class=\"bic nowrap\">")
+		if ct.Clearing != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<div class=\"clearing nowrap\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = t.T(".bic", i18n.M{"bic": ct.BIC}).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = t.T(".clearing", i18n.M{"code": ct.Clearing}).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -587,7 +587,21 @@ func paymentCreditTransferRow(ct *pay.CreditTransfer) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</div>")
+		if ct.BIC != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<div class=\"bic nowrap\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = t.T(".bic", i18n.M{"bic": ct.BIC}).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -628,12 +642,12 @@ func paymentTerms(terms *pay.Terms) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "<ul class=\"terms\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<ul class=\"terms\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if terms.Key != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<li class=\"terms-key\"><span class=\"label\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<li class=\"terms-key\"><span class=\"label\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -641,26 +655,26 @@ func paymentTerms(terms *pay.Terms) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</span> <span class=\"value\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "</span> <span class=\"value\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var16 string
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(paymentTermsKeyName(ctx, terms))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 189, Col: 39}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 194, Col: 39}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "</span></li>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</span></li>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if terms.Notes != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "<li class=\"terms-notes\"><span class=\"label\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "<li class=\"terms-notes\"><span class=\"label\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -668,26 +682,26 @@ func paymentTerms(terms *pay.Terms) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</span> <span class=\"value\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "</span> <span class=\"value\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var17 string
 				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(terms.Notes)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 199, Col: 19}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 204, Col: 19}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "</span></li>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</span></li>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if len(terms.DueDates) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<li class=\"due-dates\"><span class=\"label\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "<li class=\"due-dates\"><span class=\"label\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -695,7 +709,7 @@ func paymentTerms(terms *pay.Terms) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</span> <span class=\"value\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</span> <span class=\"value\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -703,12 +717,12 @@ func paymentTerms(terms *pay.Terms) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "</span></li>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</span></li>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</ul>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</ul>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -743,12 +757,12 @@ func paymentDueDates(terms *pay.Terms) templ.Component {
 			templ_7745c5c3_Var18 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "<table class=\"due-dates\"><tbody>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "<table class=\"due-dates\"><tbody>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, dd := range terms.DueDates {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "<tr><td class=\"date\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<tr><td class=\"date\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -758,25 +772,25 @@ func paymentDueDates(terms *pay.Terms) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "</td><td class=\"notes\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "</td><td class=\"notes\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var19 string
 			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(dd.Notes)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 228, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 233, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if dd.Percent != nil {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "<span class=\"percent\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "<span class=\"percent\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -784,12 +798,12 @@ func paymentDueDates(terms *pay.Terms) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "</td><td class=\"amount\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "</td><td class=\"amount\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -797,12 +811,12 @@ func paymentDueDates(terms *pay.Terms) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "</td></tr>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "</td></tr>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "</tbody></table>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "</tbody></table>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/examples/out/payment-multi-method.html
+++ b/examples/out/payment-multi-method.html
@@ -271,6 +271,9 @@
                       <div class="iban nowrap">
                         IBAN: ES7921000813610123456789
                       </div>
+                      <div class="clearing nowrap">
+                        Clearing code: 1234
+                      </div>
                     </div>
                     <div class="ref">
                       Reference: INV-001

--- a/examples/payment-multi-method.json
+++ b/examples/payment-multi-method.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120009",
 		"dig": {
 			"alg": "sha256",
-			"val": "73fa42f6d60560c0392c621a69a0c371a9398e8a8bd79a925e9f5c5052c9f760"
+			"val": "7efbec5be5619c5b4f5ce83ba3d45490e18d54a13dc25c4031486b43cef972c2"
 		}
 	},
 	"doc": {
@@ -85,6 +85,7 @@
 				"amount": "62.00",
 				"credit_transfer": {
 					"iban": "ES7921000813610123456789",
+					"clearing": "1234",
 					"name": "Banco Sample"
 				}
 			},

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/a-h/templ v0.3.1001
 	github.com/go-resty/resty/v2 v2.12.0
 	github.com/invopop/ctxi18n v0.9.0
-	github.com/invopop/gobl v0.502.2
+	github.com/invopop/gobl v0.504.0
 	github.com/invopop/gobl.dev v0.500.7
 	github.com/invopop/gobl.mx.cfdi v0.62.0
 	github.com/invopop/gobl.pt.saft v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/ctxi18n v0.9.0 h1:BIia4u4OngaHVn/7gvK0w6lccOXVtad8xU0KgJ+mnVA=
 github.com/invopop/ctxi18n v0.9.0/go.mod h1:1Osw+JGYA+anHt0Z4reF36r5FtGHYjGQ+m1X7keIhPc=
-github.com/invopop/gobl v0.502.2 h1:guH++uYsy5RjCjn7qGNwFq1xWLceNx0Pmjz/Fm2KCRw=
-github.com/invopop/gobl v0.502.2/go.mod h1:HmiEdQreTSQYyNbhs81VKTmI7BAJKYC/6enh9RDwnE0=
+github.com/invopop/gobl v0.504.0 h1:RLmZmeAk9RL4rkMUc7xQfC70/RGiBeekRwVgMsMthQA=
+github.com/invopop/gobl v0.504.0/go.mod h1:HmiEdQreTSQYyNbhs81VKTmI7BAJKYC/6enh9RDwnE0=
 github.com/invopop/gobl.br.nfe v0.0.1 h1:ywJycz2wiyeNygbRhuRJg52gTnIECsbZ5+pGFqh3eyE=
 github.com/invopop/gobl.br.nfe v0.0.1/go.mod h1:ZIJSVz5257xciD+RkBhyvqjtS46Pgw23idTca6A8ZIk=
 github.com/invopop/gobl.br.nfse v0.0.1 h1:BdwNiG7vk7bPMgE4m102P+UysOxmYWhOKIDfFI6RKEA=

--- a/locales/ar/app.yml
+++ b/locales/ar/app.yml
@@ -126,6 +126,7 @@ ar:
           bank_name: "البنك: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "رقم الحساب: %{num}"
+          clearing: "رمز المقاصة: %{code}"
           bic: "BIC: %{bic}"
           online: "رابط الدفع"
           methods:
@@ -356,4 +357,3 @@ ar:
         CS: "تخصيص المشارك في التأمين"
         LD: "تخصيص المشارك الرئيسي في التأمين"
         RA: "إعادة التأمين المقبولة"
-

--- a/locales/ca/app.yml
+++ b/locales/ca/app.yml
@@ -126,6 +126,7 @@ ca:
           bank_name: "Banc: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Número de compte: %{num}"
+          clearing: "Codi de compensació: %{code}"
           bic: "BIC: %{bic}"
           online: "Enllaç de pagament"
           methods:

--- a/locales/da/app.yml
+++ b/locales/da/app.yml
@@ -122,6 +122,7 @@ da:
           bank_name: "Bank: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Kontonummer: %{num}"
+          clearing: "Registreringsnummer: %{code}"
           bic: "BIC: %{bic}"
           online: "Betalingslink"
           methods:

--- a/locales/de/app.yml
+++ b/locales/de/app.yml
@@ -122,6 +122,7 @@ de:
           bank_name: "Bank: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Kontonummer: %{num}"
+          clearing: "Bankleitzahl: %{code}"
           bic: "BIC: %{bic}"
           online: "Zahlungslink"
           methods:

--- a/locales/el/app.yml
+++ b/locales/el/app.yml
@@ -124,6 +124,7 @@ el:
           bank_name: "Τράπεζα: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Αριθμός λογαριασμού: %{num}"
+          clearing: "Κωδικός εκκαθάρισης: %{code}"
           bic: "BIC: %{bic}"
           online: "Σύνδεσμος πληρωμής"
           methods:

--- a/locales/en/app.yml
+++ b/locales/en/app.yml
@@ -127,6 +127,7 @@ en:
           bank_name: "Bank: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Account number: %{num}"
+          clearing: "Clearing code: %{code}"
           bic: "BIC: %{bic}"
           online: "Payment link"
           methods:

--- a/locales/es/app.yml
+++ b/locales/es/app.yml
@@ -126,6 +126,7 @@ es:
           bank_name: "Banco: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Número de cuenta: %{num}"
+          clearing: "Código de compensación: %{code}"
           bic: "BIC: %{bic}"
           online: "Link de pago"
           methods:

--- a/locales/eu/app.yml
+++ b/locales/eu/app.yml
@@ -126,6 +126,7 @@ eu:
           bank_name: "Bankua: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Kontu zenbakia: %{num}"
+          clearing: "Konpentsazio-kodea: %{code}"
           bic: "BIC: %{bic}"
           online: "Ordainketa esteka"
           methods:

--- a/locales/fr/app.yml
+++ b/locales/fr/app.yml
@@ -113,6 +113,7 @@ fr:
           bank_name: "Banque: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Numéro de compte: %{num}"
+          clearing: "Code de compensation : %{code}"
           bic: "BIC: %{bic}"
           online: "Lien de paiement"
           methods:

--- a/locales/gl/app.yml
+++ b/locales/gl/app.yml
@@ -126,6 +126,7 @@ gl:
           bank_name: "Banco: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Número de conta: %{num}"
+          clearing: "Código de compensación: %{code}"
           bic: "BIC: %{bic}"
           online: "Ligazón de pagamento"
           methods:

--- a/locales/it/app.yml
+++ b/locales/it/app.yml
@@ -113,6 +113,7 @@ it:
           bank_name: "Banca: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Numero di conto: %{num}"
+          clearing: "Codice di compensazione: %{code}"
           bic: "BIC: %{bic}"
           online: "Link di pagamento"
           methods:

--- a/locales/nl/app.yml
+++ b/locales/nl/app.yml
@@ -122,6 +122,7 @@ nl:
           bank_name: "Bank: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Rekeningnummer: %{num}"
+          clearing: "Clearingcode: %{code}"
           bic: "BIC: %{bic}"
           online: "Betaallink"
           methods:

--- a/locales/no/app.yml
+++ b/locales/no/app.yml
@@ -122,6 +122,7 @@ no:
           bank_name: "Bank: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Kontonummer: %{num}"
+          clearing: "Clearingkode: %{code}"
           bic: "BIC: %{bic}"
           online: "Betalingslenke"
           methods:

--- a/locales/pl/app.yml
+++ b/locales/pl/app.yml
@@ -122,6 +122,7 @@ pl:
           bank_name: "Bank: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Numer konta: %{num}"
+          clearing: "Kod rozliczeniowy: %{code}"
           bic: "BIC: %{bic}"
           online: "Link do płatności"
           methods:

--- a/locales/pt/app.yml
+++ b/locales/pt/app.yml
@@ -122,6 +122,7 @@ pt:
           bank_name: "Banco: %{name}"
           iban: "IBAN: %{iban}"
           account_number: "Número da conta: %{num}"
+          clearing: "Código de compensação: %{code}"
           bic: "BIC: %{bic}"
           online: "Link de pagamento"
           methods:


### PR DESCRIPTION
## Summary

- upgrade GOBL to v0.504.0 for `pay.CreditTransfer.Clearing`
- render clearing codes alongside account and BIC details
- add localized clearing labels for every supported locale
- extend the multi-method payment example and expected HTML
- regenerate the affected Templ output with the repository-pinned generator

## Testing

- `go test ./...`
- `git diff --check`

The standalone translation validation script could not run locally because `yq` is unavailable; all locale files were checked to contain the new key.