### PR TITLE
Show identities with any valid key

### DIFF
--- a/components/org/party.templ
+++ b/components/org/party.templ
@@ -98,7 +98,7 @@ templ websites(websites []*org.Website) {
 
 templ identities(idents []*org.Identity) {
 	for _, ident := range idents {
-		if showIdentity(ctx, ident) {
+		if showIdentity(ident) {
 			<div class="identity">
 				@t.T(".identity", i18n.M{"label": identityLabel(ctx, ident), "code": ident.Code})
 			</div>
@@ -216,21 +216,13 @@ func identityLabel(ctx context.Context, ident *org.Identity) string {
 		if !strings.HasPrefix(label, "!") {
 			return label
 		}
+		return ident.Key.String()
 	}
 	return i18n.T(ctx, ".identity_code")
 }
 
-func showIdentity(ctx context.Context, ident *org.Identity) bool {
-	if ident.Label != "" || ident.Type != "" {
-		return true
-	}
-	if ident.Key != "" {
-		// ctxi18n returns "!(MISSING: <key>)" when no translation is
-		// defined, so a "!" prefix means the key has no label to show.
-		label := i18n.T(ctx, fmt.Sprintf(".identity_labels.%s", ident.Key))
-		return !strings.HasPrefix(label, "!")
-	}
-	return false
+func showIdentity(ident *org.Identity) bool {
+	return ident.Label != "" || ident.Type != "" || ident.Key != ""
 }
 
 func showTaxID(party *org.Party) bool {

--- a/components/org/party_templ.go
+++ b/components/org/party_templ.go
@@ -461,7 +461,7 @@ func identities(idents []*org.Identity) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		for _, ident := range idents {
-			if showIdentity(ctx, ident) {
+			if showIdentity(ident) {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"identity\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -766,21 +766,13 @@ func identityLabel(ctx context.Context, ident *org.Identity) string {
 		if !strings.HasPrefix(label, "!") {
 			return label
 		}
+		return ident.Key.String()
 	}
 	return i18n.T(ctx, ".identity_code")
 }
 
-func showIdentity(ctx context.Context, ident *org.Identity) bool {
-	if ident.Label != "" || ident.Type != "" {
-		return true
-	}
-	if ident.Key != "" {
-		// ctxi18n returns "!(MISSING: <key>)" when no translation is
-		// defined, so a "!" prefix means the key has no label to show.
-		label := i18n.T(ctx, fmt.Sprintf(".identity_labels.%s", ident.Key))
-		return !strings.HasPrefix(label, "!")
-	}
-	return false
+func showIdentity(ident *org.Identity) bool {
+	return ident.Label != "" || ident.Type != "" || ident.Key != ""
 }
 
 func showTaxID(party *org.Party) bool {


### PR DESCRIPTION
## What changed

Party identities with a key are now always displayed, even when the key has no `identity_labels` translation. When no translation exists, the key itself is used as the label instead of the generic "Identity code" text.

## Why

#132 hid identities that only had a bare code, but it also hid identities with a key unless that key had a matching translation (currently only `it-fiscal-code` and `de-tax-number`). A key like `internal-ref` is meaningful and validated upstream in GOBL, so it should be shown.

## Notes for reviewers

- `showIdentity` is now a plain field check (label, type, or key present) and no longer needs `ctx`.
- `identityLabel` fallback chain is: explicit label → type → key translation → the key itself → generic "Identity code" (only reachable for bare-code identities, which remain hidden).
- No example outputs changed: the examples hidden by #132 are bare-code identities and stay hidden, and no example has a party identity with an untranslated key.
- Line-item and ordering identities still require a label/type — unchanged here, can be aligned in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)