### PR TITLE
Render German tax ID as unbroken USt-IdNr.

### DIFF
--- a/components/org/party.templ
+++ b/components/org/party.templ
@@ -39,7 +39,11 @@ templ Party(party *org.Party) {
 templ taxID(party *org.Party) {
 	if showTaxID(party) {
 		<div class="tax-id">
-			@t.T(".tax_id", i18n.M{"label": taxIDLabel(ctx, party), "country": party.TaxID.Country.String(), "code": taxIDCode(party)})
+			if taxIDCodeIncludesCountry(party) {
+				@t.T(".tax_id_no_country", i18n.M{"label": taxIDLabel(ctx, party), "code": taxIDCode(party)})
+			} else {
+				@t.T(".tax_id", i18n.M{"label": taxIDLabel(ctx, party), "country": party.TaxID.Country.String(), "code": taxIDCode(party)})
+			}
 		</div>
 	}
 }
@@ -234,6 +238,8 @@ func taxIDLabel(ctx context.Context, party *org.Party) string {
 	switch tID.Country {
 	case "AR":
 		return "CUIT"
+	case "DE":
+		return "USt-IdNr."
 	case "ES":
 		return "NIF"
 	case "CO":
@@ -258,8 +264,19 @@ func taxIDCode(party *org.Party) string {
 	case "CO":
 		return co.FormatTaxIDCode(code)
 	default:
-		return tID.Code.String()
+		if taxIDCodeIncludesCountry(party) {
+			return tID.Country.String() + code
+		}
+		return code
 	}
+}
+
+// taxIDCodeIncludesCountry reports whether the country prefix is an
+// integral part of the tax ID code, in which case it is prepended to
+// the code and not shown separately in parentheses. The German
+// USt-IdNr., for example, is only valid with the "DE" prefix.
+func taxIDCodeIncludesCountry(party *org.Party) bool {
+	return party.TaxID.Country == "DE"
 }
 
 func mapPartyExtension(ctx context.Context, k cbc.Key, v cbc.Code) string {

--- a/components/org/party_templ.go
+++ b/components/org/party_templ.go
@@ -216,9 +216,16 @@ func taxID(party *org.Party) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = t.T(".tax_id", i18n.M{"label": taxIDLabel(ctx, party), "country": party.TaxID.Country.String(), "code": taxIDCode(party)}).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
+			if taxIDCodeIncludesCountry(party) {
+				templ_7745c5c3_Err = t.T(".tax_id_no_country", i18n.M{"label": taxIDLabel(ctx, party), "code": taxIDCode(party)}).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = t.T(".tax_id", i18n.M{"label": taxIDLabel(ctx, party), "country": party.TaxID.Country.String(), "code": taxIDCode(party)}).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div>")
 			if templ_7745c5c3_Err != nil {
@@ -534,7 +541,7 @@ func registration(reg *org.Registration) templ.Component {
 					var templ_7745c5c3_Var14 string
 					templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(reg.Office)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 118, Col: 18}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 122, Col: 18}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 					if templ_7745c5c3_Err != nil {
@@ -637,7 +644,7 @@ func registration(reg *org.Registration) templ.Component {
 					var templ_7745c5c3_Var15 string
 					templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(reg.Other)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 153, Col: 17}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 157, Col: 17}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 					if templ_7745c5c3_Err != nil {
@@ -707,7 +714,7 @@ func partyExtensions(party *org.Party) templ.Component {
 				var templ_7745c5c3_Var17 string
 				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(txt)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 170, Col: 9}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 174, Col: 9}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 				if templ_7745c5c3_Err != nil {
@@ -784,6 +791,8 @@ func taxIDLabel(ctx context.Context, party *org.Party) string {
 	switch tID.Country {
 	case "AR":
 		return "CUIT"
+	case "DE":
+		return "USt-IdNr."
 	case "ES":
 		return "NIF"
 	case "CO":
@@ -808,8 +817,19 @@ func taxIDCode(party *org.Party) string {
 	case "CO":
 		return co.FormatTaxIDCode(code)
 	default:
-		return tID.Code.String()
+		if taxIDCodeIncludesCountry(party) {
+			return tID.Country.String() + code
+		}
+		return code
 	}
+}
+
+// taxIDCodeIncludesCountry reports whether the country prefix is an
+// integral part of the tax ID code, in which case it is prepended to
+// the code and not shown separately in parentheses. The German
+// USt-IdNr., for example, is only valid with the "DE" prefix.
+func taxIDCodeIncludesCountry(party *org.Party) bool {
+	return party.TaxID.Country == "DE"
 }
 
 func mapPartyExtension(ctx context.Context, k cbc.Key, v cbc.Code) string {

--- a/examples/out/de-choruspro-invoice.html
+++ b/examples/out/de-choruspro-invoice.html
@@ -99,7 +99,7 @@
                     Email: billing@example.com
                   </div>
                   <div class="tax-id">
-                    TIN: (DE) 111111125
+                    USt-IdNr.: DE111111125
                   </div>
                 </div>
               </div>

--- a/examples/out/de-invoice.html
+++ b/examples/out/de-invoice.html
@@ -91,7 +91,7 @@
                     Email: billing@example.com
                   </div>
                   <div class="tax-id">
-                    TIN: (DE) 111111125
+                    USt-IdNr.: DE111111125
                   </div>
                 </div>
               </div>
@@ -111,7 +111,7 @@
                     </span>
                   </div>
                   <div class="tax-id">
-                    TIN: (DE) 111111125
+                    USt-IdNr.: DE111111125
                   </div>
                 </div>
               </div>

--- a/examples/out/fr-ctc-invoice-b2bint.html
+++ b/examples/out/fr-ctc-invoice-b2bint.html
@@ -125,7 +125,7 @@
                     Email: buchhaltung@kunde.de
                   </div>
                   <div class="tax-id">
-                    TIN: (DE) 111111125
+                    USt-IdNr.: DE111111125
                   </div>
                 </div>
               </div>

--- a/locales/ar/app.yml
+++ b/locales/ar/app.yml
@@ -228,6 +228,7 @@ ar:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       person: "%{name}"
       person_label: "%{label}: %{name}"
       tel: "هاتف: %{num}"

--- a/locales/ca/app.yml
+++ b/locales/ca/app.yml
@@ -228,6 +228,7 @@ ca:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       person: "%{name}"
       person_label: "%{label}: %{name}"
       tel: "Tel: %{num}"

--- a/locales/da/app.yml
+++ b/locales/da/app.yml
@@ -224,6 +224,7 @@ da:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       tel: "Tlf.: %{num}"
       tel_label: "Tlf.: %{num} (%{label})"
       email:

--- a/locales/de/app.yml
+++ b/locales/de/app.yml
@@ -224,6 +224,7 @@ de:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       tel: "Tel: %{num}"
       tel_label: "Tel: %{num} (%{label})"
       email:

--- a/locales/el/app.yml
+++ b/locales/el/app.yml
@@ -225,6 +225,7 @@ el:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       tel: "Τηλ: %{num}"
       tel_label: "Τηλ: %{num} (%{label})"
       email:

--- a/locales/en/app.yml
+++ b/locales/en/app.yml
@@ -229,6 +229,7 @@ en:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       person: "%{name}"
       person_label: "%{label}: %{name}"
       tel: "Tel: %{num}"

--- a/locales/es/app.yml
+++ b/locales/es/app.yml
@@ -228,6 +228,7 @@ es:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       tel: "Tel: %{num}"
       tel_label: "Tel: %{num} (%{label})"
       email:

--- a/locales/eu/app.yml
+++ b/locales/eu/app.yml
@@ -228,6 +228,7 @@ eu:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       person: "%{name}"
       person_label: "%{label}: %{name}"
       tel: "Tel: %{num}"

--- a/locales/fr/app.yml
+++ b/locales/fr/app.yml
@@ -214,6 +214,7 @@ fr:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       tel: "Tél: %{num}"
       tel_label: "Tél: %{num} (%{label})"
       email:

--- a/locales/gl/app.yml
+++ b/locales/gl/app.yml
@@ -228,6 +228,7 @@ gl:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       person: "%{name}"
       person_label: "%{label}: %{name}"
       tel: "Tel: %{num}"

--- a/locales/it/app.yml
+++ b/locales/it/app.yml
@@ -213,6 +213,7 @@ it:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       tel: "Tel: %{num}"
       tel_label: "Tel: %{num} (%{label})"
       email:

--- a/locales/nl/app.yml
+++ b/locales/nl/app.yml
@@ -224,6 +224,7 @@ nl:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       tel: "Tel.: %{num}"
       tel_label: "Tel.: %{num} (%{label})"
       email:

--- a/locales/no/app.yml
+++ b/locales/no/app.yml
@@ -224,6 +224,7 @@ no:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       tel: "Tlf.: %{num}"
       tel_label: "Tlf.: %{num} (%{label})"
       email:

--- a/locales/pl/app.yml
+++ b/locales/pl/app.yml
@@ -223,6 +223,7 @@ pl:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       tel: "Tel: %{num}"
       tel_label: "Tel: %{num} (%{label})"
       email:

--- a/locales/pt/app.yml
+++ b/locales/pt/app.yml
@@ -223,6 +223,7 @@ pt:
   org:
     party:
       tax_id: "%{label}: (%{country}) %{code}"
+      tax_id_no_country: "%{label}: %{code}"
       tel: "Tel: %{num}"
       tel_label: "Tel: %{num} (%{label})"
       email:


### PR DESCRIPTION
## Summary

German VAT identification numbers were rendered as `TIN: (DE) 111111125`, which has two problems:

- The `DE` prefix is an integral part of the USt-IdNr. — the canonical form is `DE111111125`, and the split/parenthesized rendering breaks copy-paste into VIES or other validation lookups.
- The generic label (`TIN` / `Umsatzsteuer`) is ambiguous for German recipients, who could mistake the value for the Finanzamt-issued Steuernummer.

German tax IDs now render as `USt-IdNr.: DE111111125`.

## Changes

- Add `DE` → `USt-IdNr.` to the `taxIDLabel` switch in `components/org/party.templ`.
- Add a `taxIDCodeIncludesCountry` helper: when the country prefix is part of the identifier, it is prepended to the code and the parenthesized country is dropped. Currently only enabled for `DE`, but easy to extend to other EU VAT IDs.
- Add a `tax_id_no_country` format string to all locales.
- Regenerate templ output and example HTML files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)