### PR TITLE
Display UNTDID unit codes alongside GOBL units

### DIFF
--- a/components/bill/line_support.go
+++ b/components/bill/line_support.go
@@ -1,6 +1,7 @@
 package bill
 
 import (
+	"github.com/invopop/gobl.html/components/t"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
@@ -31,7 +32,7 @@ func prepareLineSupport(reg *tax.RegimeDef, lines []*bill.Line, dss []*bill.Disc
 		if len(l.Charges) > 0 {
 			ls.charges = true
 		}
-		if l.Item.Unit != "" {
+		if t.ItemHasUnit(l.Item) {
 			ls.units = true
 		}
 		if l.Item.Price != nil {

--- a/components/bill/line_support_test.go
+++ b/components/bill/line_support_test.go
@@ -1,0 +1,22 @@
+package bill
+
+import (
+	"testing"
+
+	gbill "github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrepareLineSupportUNTDIDUnit(t *testing.T) {
+	lines := []*gbill.Line{
+		{
+			Item: &org.Item{
+				Ext: tax.MakeExtensions().Set("untdid-unit", "E48"),
+			},
+		},
+	}
+
+	assert.True(t, prepareLineSupport(new(tax.RegimeDef), lines, nil, nil).units)
+}

--- a/components/bill/lines.templ
+++ b/components/bill/lines.templ
@@ -124,8 +124,8 @@ templ line(l *bill.Line, ls *lineSupport, st *subtotal) {
 		</td>
 		if ls.units {
 			<td class="unit">
-				if l.Item.Unit != "" {
-					{ t.UnitName(ctx, l.Item.Unit) }
+				if t.ItemHasUnit(l.Item) {
+					{ t.ItemUnitName(ctx, l.Item) }
 				} else {
 					<!-- empty -->
 				}
@@ -223,8 +223,8 @@ templ breakdownLine(sl *bill.SubLine, ls *lineSupport, st *subtotal) {
 		</td>
 		if ls.units {
 			<td class="unit">
-				if sl.Item.Unit != "" {
-					{ t.UnitName(ctx, sl.Item.Unit) }
+				if t.ItemHasUnit(sl.Item) {
+					{ t.ItemUnitName(ctx, sl.Item) }
 				} else {
 					<!-- empty -->
 				}

--- a/components/bill/lines_templ.go
+++ b/components/bill/lines_templ.go
@@ -440,11 +440,11 @@ func line(l *bill.Line, ls *lineSupport, st *subtotal) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if l.Item.Unit != "" {
+			if t.ItemHasUnit(l.Item) {
 				var templ_7745c5c3_Var12 string
-				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(t.UnitName(ctx, l.Item.Unit))
+				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(t.ItemUnitName(ctx, l.Item))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 128, Col: 35}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 128, Col: 34}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -743,11 +743,11 @@ func breakdownLine(sl *bill.SubLine, ls *lineSupport, st *subtotal) templ.Compon
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if sl.Item.Unit != "" {
+			if t.ItemHasUnit(sl.Item) {
 				var templ_7745c5c3_Var19 string
-				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(t.UnitName(ctx, sl.Item.Unit))
+				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(t.ItemUnitName(ctx, sl.Item))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 227, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 227, Col: 35}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 				if templ_7745c5c3_Err != nil {

--- a/components/t/units.go
+++ b/components/t/units.go
@@ -2,10 +2,14 @@ package t
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/invopop/ctxi18n/i18n"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
 )
+
+const untdidUnitExtension cbc.Key = "untdid-unit"
 
 var unitDefs = func() map[org.Unit]*org.DefUnit {
 	m := make(map[org.Unit]*org.DefUnit, len(org.UnitDefinitions))
@@ -29,4 +33,28 @@ func UnitName(ctx context.Context, u org.Unit) string {
 		return def.Symbol
 	}
 	return i18n.T(ctx, "units."+string(u), i18n.Default(def.Name))
+}
+
+// ItemUnitName provides the display name for an item's unit. When the item
+// contains a UNTDID unit extension, the code is appended to the GOBL unit
+// name, or used on its own if the item does not have a GOBL unit.
+func ItemUnitName(ctx context.Context, item *org.Item) string {
+	if item == nil {
+		return ""
+	}
+	name := UnitName(ctx, item.Unit)
+	code := item.Ext.Get(untdidUnitExtension).String()
+	if name == "" {
+		return code
+	}
+	if code == "" {
+		return name
+	}
+	return fmt.Sprintf("%s (%s)", name, code)
+}
+
+// ItemHasUnit reports whether an item has either a GOBL unit or a UNTDID unit
+// extension that can be displayed.
+func ItemHasUnit(item *org.Item) bool {
+	return item != nil && (item.Unit != "" || item.Ext.Has(untdidUnitExtension))
 }

--- a/components/t/units_test.go
+++ b/components/t/units_test.go
@@ -8,6 +8,7 @@ import (
 	ct "github.com/invopop/gobl.html/components/t"
 	srclocales "github.com/invopop/gobl.html/locales"
 	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,4 +70,48 @@ func TestUnitName(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestItemUnitName(t *testing.T) {
+	locales := new(i18n.Locales)
+	require.NoError(t, locales.LoadWithDefault(srclocales.Content, "en"))
+	ctx := locales.Get("en").WithContext(context.Background())
+
+	tests := []struct {
+		name string
+		item *org.Item
+		want string
+	}{
+		{name: "nil item", want: ""},
+		{name: "empty item", item: &org.Item{}, want: ""},
+		{name: "GOBL unit", item: &org.Item{Unit: org.UnitKilogram}, want: "kg"},
+		{
+			name: "GOBL and UNTDID units",
+			item: &org.Item{
+				Unit: org.UnitKilogram,
+				Ext:  tax.MakeExtensions().Set("untdid-unit", "KGM"),
+			},
+			want: "kg (KGM)",
+		},
+		{
+			name: "translated GOBL and UNTDID units",
+			item: &org.Item{
+				Unit: org.UnitHour,
+				Ext:  tax.MakeExtensions().Set("untdid-unit", "HUR"),
+			},
+			want: "hours (HUR)",
+		},
+		{
+			name: "UNTDID unit only",
+			item: &org.Item{Ext: tax.MakeExtensions().Set("untdid-unit", "E48")},
+			want: "E48",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, ct.ItemUnitName(ctx, test.item))
+			assert.Equal(t, test.want != "", ct.ItemHasUnit(test.item))
+		})
+	}
 }

--- a/examples/fr-invoice-units.fr.json
+++ b/examples/fr-invoice-units.fr.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "9c9d0b43c26dc5f4a0d36089b7bcd78657b1eab4172119da39b6f167578cd39d"
+			"val": "5169c45e6bb7dc8ba4e49f960ac5a2b0718beb4b0a6b258e90916aee1dabb63b"
 		}
 	},
 	"doc": {
@@ -177,9 +177,7 @@
 				"item": {
 					"name": "Eau minérale",
 					"price": "1.20",
-					"ext": {
-						"untdid-unit": "XBO"
-					}
+					"unit": "bottle"
 				},
 				"sum": "14.40",
 				"taxes": [
@@ -191,11 +189,32 @@
 					}
 				],
 				"total": "14.40"
+			},
+			{
+				"i": 8,
+				"quantity": "1",
+				"item": {
+					"name": "Prestation avec unité UNTDID",
+					"price": "10.00",
+					"ext": {
+						"untdid-unit": "E48"
+					}
+				},
+				"sum": "10.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "20%"
+					}
+				],
+				"total": "10.00"
 			}
 		],
 		"totals": {
-			"sum": "4350.40",
-			"total": "4350.40",
+			"sum": "4360.40",
+			"total": "4360.40",
 			"taxes": {
 				"categories": [
 					{
@@ -203,19 +222,19 @@
 						"rates": [
 							{
 								"key": "standard",
-								"base": "4350.40",
+								"base": "4360.40",
 								"percent": "20%",
-								"amount": "870.08"
+								"amount": "872.08"
 							}
 						],
-						"amount": "870.08"
+						"amount": "872.08"
 					}
 				],
-				"sum": "870.08"
+				"sum": "872.08"
 			},
-			"tax": "870.08",
-			"total_with_tax": "5220.48",
-			"payable": "5220.48"
+			"tax": "872.08",
+			"total_with_tax": "5232.48",
+			"payable": "5232.48"
 		}
 	}
 }

--- a/examples/fr-invoice-units.fr.json
+++ b/examples/fr-invoice-units.fr.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "e588d036427eab5deef69c8855be9be469cb7a95f63be5f90a6ccb87d01926a5"
+			"val": "9c9d0b43c26dc5f4a0d36089b7bcd78657b1eab4172119da39b6f167578cd39d"
 		}
 	},
 	"doc": {
@@ -155,7 +155,10 @@
 				"item": {
 					"name": "Café en grains",
 					"price": "9.80",
-					"unit": "kg"
+					"unit": "kg",
+					"ext": {
+						"untdid-unit": "KGM"
+					}
 				},
 				"sum": "245.00",
 				"taxes": [
@@ -174,7 +177,9 @@
 				"item": {
 					"name": "Eau minérale",
 					"price": "1.20",
-					"unit": "bottle"
+					"ext": {
+						"untdid-unit": "XBO"
+					}
 				},
 				"sum": "14.40",
 				"taxes": [

--- a/examples/out/fr-invoice-units.fr.html
+++ b/examples/out/fr-invoice-units.fr.html
@@ -299,7 +299,7 @@
                   25
                 </td>
                 <td class="unit">
-                  kg
+                  kg (KGM)
                 </td>
                 <td class="price">
                   €9,80
@@ -326,7 +326,7 @@
                   12
                 </td>
                 <td class="unit">
-                  bouteilles
+                  XBO
                 </td>
                 <td class="price">
                   €1,20

--- a/examples/out/fr-invoice-units.fr.html
+++ b/examples/out/fr-invoice-units.fr.html
@@ -326,7 +326,7 @@
                   12
                 </td>
                 <td class="unit">
-                  XBO
+                  bouteilles
                 </td>
                 <td class="price">
                   €1,20
@@ -336,6 +336,33 @@
                 </td>
                 <td class="total">
                   €14,40
+                </td>
+              </tr>
+              <tr data-subtotal="€4.360,40">
+                <td class="ref">
+                  8
+                </td>
+                <td class="description">
+                  <div class="limited-height">
+                    <span>
+                      Prestation avec unité UNTDID
+                    </span>
+                  </div>
+                </td>
+                <td class="quantity">
+                  1
+                </td>
+                <td class="unit">
+                  E48
+                </td>
+                <td class="price">
+                  €10,00
+                </td>
+                <td class="tax">
+                  20%
+                </td>
+                <td class="total">
+                  €10,00
                 </td>
               </tr>
             </tbody>
@@ -354,7 +381,7 @@
                       Somme
                     </th>
                     <td>
-                      €4.350,40
+                      €4.360,40
                     </td>
                   </tr>
                   <tr class="tax">
@@ -362,7 +389,7 @@
                       Taxe
                     </th>
                     <td>
-                      €870,08
+                      €872,08
                     </td>
                   </tr>
                   <tr class="payable strong">
@@ -370,7 +397,7 @@
                       Total à payer
                     </th>
                     <td>
-                      €5.220,48
+                      €5.232,48
                     </td>
                   </tr>
                 </tbody>
@@ -403,13 +430,13 @@
                       TVA
                     </td>
                     <td class="base">
-                      €4.350,40
+                      €4.360,40
                     </td>
                     <td class="rate">
                       20%
                     </td>
                     <td class="amount">
-                      €870,08
+                      €872,08
                     </td>
                   </tr>
                 </tbody>


### PR DESCRIPTION
## Summary

- display a UNTDID unit code after the localized GOBL unit representation, for example `kg (KGM)`
- display the UNTDID code by itself when an item has no GOBL unit
- include the unit column for extension-only units
- add focused formatter and line-support tests
- update the unit-focused French invoice example to cover GOBL-only, combined GOBL/UNTDID, and UNTDID-only rendering

This follows [invopop/gobl#929](https://github.com/invopop/gobl/pull/929). The extension key is read directly so this change remains compatible with the currently released GOBL dependency while that breaking refactor and its downstream dependency migrations are pending.

## Validation

- `go test ./components/t ./components/bill`
- targeted `fr-invoice-units.fr` snapshot test
- `go test ./... -run "^$"`
- `golangci-lint run ./...`
- changed unit formatter functions have 100% coverage

The complete repository test command currently reports existing snapshot drift in `party.hide.html`, `smoobu.hide.html`, and `smoobu-out.hide.html`: their stored German tax-ID labels differ from current renderer output. This PR deliberately does not update those unrelated snapshots.