### PR TITLE
Add a generic tax ID formatter

### DIFF
--- a/components/bill/lines.templ
+++ b/components/bill/lines.templ
@@ -5,6 +5,7 @@ import (
 	"github.com/invopop/ctxi18n/i18n"
 	"github.com/invopop/gobl.html/components/regimes/mx"
 	"github.com/invopop/gobl.html/components/t"
+	"github.com/invopop/gobl.html/components/taxid"
 	"github.com/invopop/gobl.html/components/utils"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
@@ -303,7 +304,7 @@ templ defaultLineSeller(seller *org.Party) {
 		{ seller.Name }
 		if seller.TaxID != nil && seller.TaxID.Code != "" {
 			{ " · " }
-			<code>{ seller.TaxID.Code.String() }</code>
+			<code>{ taxid.Format(ctx, seller.TaxID).Code }</code>
 		}
 	</span>
 }

--- a/components/bill/lines_templ.go
+++ b/components/bill/lines_templ.go
@@ -13,6 +13,7 @@ import (
 	"github.com/invopop/ctxi18n/i18n"
 	"github.com/invopop/gobl.html/components/regimes/mx"
 	"github.com/invopop/gobl.html/components/t"
+	"github.com/invopop/gobl.html/components/taxid"
 	"github.com/invopop/gobl.html/components/utils"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
@@ -190,7 +191,7 @@ func linesWithSupport(reg *tax.RegimeDef, lines []*bill.Line, dss []*bill.Discou
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(cat.Name.In(t.Lang(ctx)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 62, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 63, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -321,7 +322,7 @@ func line(l *bill.Line, ls *lineSupport, st *subtotal) templ.Component {
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(t.LocalizeMoney(ctx, st.Add(l.Total)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 94, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 95, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
@@ -334,7 +335,7 @@ func line(l *bill.Line, ls *lineSupport, st *subtotal) templ.Component {
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(l.Index))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 96, Col: 24}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 97, Col: 24}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
@@ -347,7 +348,7 @@ func line(l *bill.Line, ls *lineSupport, st *subtotal) templ.Component {
 		var templ_7745c5c3_Var9 string
 		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(l.Item.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 100, Col: 23}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 101, Col: 23}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
@@ -365,7 +366,7 @@ func line(l *bill.Line, ls *lineSupport, st *subtotal) templ.Component {
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(l.Item.Description)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 103, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 104, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -392,7 +393,7 @@ func line(l *bill.Line, ls *lineSupport, st *subtotal) templ.Component {
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(l.Item.Ref.String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 111, Col: 28}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 112, Col: 28}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -444,7 +445,7 @@ func line(l *bill.Line, ls *lineSupport, st *subtotal) templ.Component {
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(t.UnitName(ctx, l.Item.Unit))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 128, Col: 35}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 129, Col: 35}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -569,7 +570,7 @@ func line(l *bill.Line, ls *lineSupport, st *subtotal) templ.Component {
 						var templ_7745c5c3_Var13 string
 						templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(code)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 174, Col: 14}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 175, Col: 14}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 						if templ_7745c5c3_Err != nil {
@@ -645,7 +646,7 @@ func breakdownLine(sl *bill.SubLine, ls *lineSupport, st *subtotal) templ.Compon
 		var templ_7745c5c3_Var15 string
 		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(t.LocalizeMoney(ctx, st.Add(sl.Total)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 195, Col: 77}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 196, Col: 77}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
@@ -658,7 +659,7 @@ func breakdownLine(sl *bill.SubLine, ls *lineSupport, st *subtotal) templ.Compon
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(sl.Item.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 201, Col: 24}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 202, Col: 24}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
@@ -676,7 +677,7 @@ func breakdownLine(sl *bill.SubLine, ls *lineSupport, st *subtotal) templ.Compon
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(sl.Item.Description)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 204, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 205, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
@@ -703,7 +704,7 @@ func breakdownLine(sl *bill.SubLine, ls *lineSupport, st *subtotal) templ.Compon
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(sl.Item.Ref.String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 212, Col: 29}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 213, Col: 29}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 			if templ_7745c5c3_Err != nil {
@@ -747,7 +748,7 @@ func breakdownLine(sl *bill.SubLine, ls *lineSupport, st *subtotal) templ.Compon
 				var templ_7745c5c3_Var19 string
 				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(t.UnitName(ctx, sl.Item.Unit))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 227, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 228, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 				if templ_7745c5c3_Err != nil {
@@ -1046,7 +1047,7 @@ func defaultLineSeller(seller *org.Party) templ.Component {
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(seller.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 303, Col: 15}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 304, Col: 15}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
@@ -1060,7 +1061,7 @@ func defaultLineSeller(seller *org.Party) templ.Component {
 			var templ_7745c5c3_Var27 string
 			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(" · ")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 305, Col: 11}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 306, Col: 11}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 			if templ_7745c5c3_Err != nil {
@@ -1071,9 +1072,9 @@ func defaultLineSeller(seller *org.Party) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var28 string
-			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(seller.TaxID.Code.String())
+			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(taxid.Format(ctx, seller.TaxID).Code)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 306, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 307, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {
@@ -1123,7 +1124,7 @@ func identities(idents []*org.Identity) templ.Component {
 					var templ_7745c5c3_Var30 string
 					templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(ident.Label)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 317, Col: 19}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 318, Col: 19}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 					if templ_7745c5c3_Err != nil {
@@ -1133,7 +1134,7 @@ func identities(idents []*org.Identity) templ.Component {
 					var templ_7745c5c3_Var31 string
 					templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(ident.Type.String())
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 319, Col: 27}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 320, Col: 27}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 					if templ_7745c5c3_Err != nil {
@@ -1147,7 +1148,7 @@ func identities(idents []*org.Identity) templ.Component {
 				var templ_7745c5c3_Var32 string
 				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(ident.Code.String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 323, Col: 26}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 324, Col: 26}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 				if templ_7745c5c3_Err != nil {
@@ -1193,7 +1194,7 @@ func linePeriod(p *cal.Period) templ.Component {
 				var templ_7745c5c3_Var34 string
 				templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(p.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 335, Col: 14}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 336, Col: 14}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 				if templ_7745c5c3_Err != nil {
@@ -1428,7 +1429,7 @@ func groupCharges(charges []*bill.LineCharge) templ.Component {
 				var templ_7745c5c3_Var41 string
 				templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(c.Code.String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 382, Col: 22}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 383, Col: 22}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 				if templ_7745c5c3_Err != nil {
@@ -1528,7 +1529,7 @@ func discountRow(row *bill.Discount, ls *lineSupport, st *subtotal) templ.Compon
 		var templ_7745c5c3_Var44 string
 		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(t.LocalizeMoney(ctx, st.Substract(&row.Amount)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 405, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 406, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 		if templ_7745c5c3_Err != nil {
@@ -1541,7 +1542,7 @@ func discountRow(row *bill.Discount, ls *lineSupport, st *subtotal) templ.Compon
 		var templ_7745c5c3_Var45 string
 		templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("D%d", row.Index))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 407, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 408, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 		if templ_7745c5c3_Err != nil {
@@ -1554,7 +1555,7 @@ func discountRow(row *bill.Discount, ls *lineSupport, st *subtotal) templ.Compon
 		var templ_7745c5c3_Var46 string
 		templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(row.Reason)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 410, Col: 15}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 411, Col: 15}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 		if templ_7745c5c3_Err != nil {
@@ -1580,7 +1581,7 @@ func discountRow(row *bill.Discount, ls *lineSupport, st *subtotal) templ.Compon
 			var templ_7745c5c3_Var47 string
 			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(row.Code.String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 417, Col: 25}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 418, Col: 25}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 			if templ_7745c5c3_Err != nil {
@@ -1759,7 +1760,7 @@ func chargeRow(row *bill.Charge, ls *lineSupport, st *subtotal) templ.Component 
 		var templ_7745c5c3_Var50 string
 		templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(t.LocalizeMoney(ctx, st.Add(&row.Amount)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 486, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 487, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 		if templ_7745c5c3_Err != nil {
@@ -1772,7 +1773,7 @@ func chargeRow(row *bill.Charge, ls *lineSupport, st *subtotal) templ.Component 
 		var templ_7745c5c3_Var51 string
 		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("C%d", row.Index))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 488, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 489, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 		if templ_7745c5c3_Err != nil {
@@ -1785,7 +1786,7 @@ func chargeRow(row *bill.Charge, ls *lineSupport, st *subtotal) templ.Component 
 		var templ_7745c5c3_Var52 string
 		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(row.Reason)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 491, Col: 15}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 492, Col: 15}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 		if templ_7745c5c3_Err != nil {
@@ -1811,7 +1812,7 @@ func chargeRow(row *bill.Charge, ls *lineSupport, st *subtotal) templ.Component 
 			var templ_7745c5c3_Var53 string
 			templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(row.Code.String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 498, Col: 25}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/lines.templ`, Line: 499, Col: 25}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 			if templ_7745c5c3_Err != nil {

--- a/components/org/party.templ
+++ b/components/org/party.templ
@@ -9,9 +9,9 @@ import (
 	"unicode/utf8"
 
 	"github.com/invopop/ctxi18n/i18n"
-	"github.com/invopop/gobl.html/components/regimes/co"
 	"github.com/invopop/gobl.html/components/regimes/sg"
 	"github.com/invopop/gobl.html/components/t"
+	"github.com/invopop/gobl.html/components/taxid"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
 )
@@ -41,11 +41,12 @@ templ Party(party *org.Party) {
 
 templ taxID(party *org.Party) {
 	if showTaxID(party) {
+		{{ tID := taxid.Format(ctx, party.TaxID) }}
 		<div class="tax-id">
-			if taxIDCodeIncludesCountry(party) {
-				@t.T(".tax_id_no_country", i18n.M{"label": taxIDLabel(ctx, party), "code": taxIDCode(party)})
+			if tID.Country == "" {
+				@t.T(".tax_id_no_country", i18n.M{"label": tID.Label, "code": tID.Code})
 			} else {
-				@t.T(".tax_id", i18n.M{"label": taxIDLabel(ctx, party), "country": party.TaxID.Country.String(), "code": taxIDCode(party)})
+				@t.T(".tax_id", i18n.M{"label": tID.Label, "country": tID.Country, "code": tID.Code})
 			}
 		</div>
 	}
@@ -248,54 +249,6 @@ func showIdentity(ident *org.Identity) bool {
 
 func showTaxID(party *org.Party) bool {
 	return party.TaxID != nil && party.TaxID.Code != cbc.CodeEmpty
-}
-
-func taxIDLabel(ctx context.Context, party *org.Party) string {
-	tID := party.TaxID
-	switch tID.Country {
-	case "AR":
-		return "CUIT"
-	case "SG":
-		return "GST Reg No."
-	case "DE":
-		return "USt-IdNr."
-	case "ES":
-		return "NIF"
-	case "CO":
-		return "NIT"
-	case "MX":
-		return "RFC"
-	case "FR":
-		return "TVA"
-	case "PT":
-		return "NIF"
-	case "IT":
-		return "P.IVA"
-	default:
-		return i18n.T(ctx, ".labels.default")
-	}
-}
-
-func taxIDCode(party *org.Party) string {
-	tID := party.TaxID
-	code := tID.Code.String()
-	switch tID.Country {
-	case "CO":
-		return co.FormatTaxIDCode(code)
-	default:
-		if taxIDCodeIncludesCountry(party) {
-			return tID.Country.String() + code
-		}
-		return code
-	}
-}
-
-// taxIDCodeIncludesCountry reports whether the country prefix is an
-// integral part of the tax ID code, in which case it is prepended to
-// the code and not shown separately in parentheses. The German
-// USt-IdNr., for example, is only valid with the "DE" prefix.
-func taxIDCodeIncludesCountry(party *org.Party) bool {
-	return party.TaxID.Country == "DE"
 }
 
 func mapPartyExtension(ctx context.Context, k cbc.Key, v cbc.Code) string {

--- a/components/org/party_templ.go
+++ b/components/org/party_templ.go
@@ -17,9 +17,9 @@ import (
 	"unicode/utf8"
 
 	"github.com/invopop/ctxi18n/i18n"
-	"github.com/invopop/gobl.html/components/regimes/co"
 	"github.com/invopop/gobl.html/components/regimes/sg"
 	"github.com/invopop/gobl.html/components/t"
+	"github.com/invopop/gobl.html/components/taxid"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
 )
@@ -69,7 +69,7 @@ func Party(party *org.Party) templ.Component {
 				var templ_7745c5c3_Var3 string
 				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(party.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 22, Col: 34}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 23, Col: 34}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 				if templ_7745c5c3_Err != nil {
@@ -92,7 +92,7 @@ func Party(party *org.Party) templ.Component {
 				var templ_7745c5c3_Var4 string
 				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(party.Alias)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 25, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 26, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
@@ -215,17 +215,18 @@ func taxID(party *org.Party) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		if showTaxID(party) {
+			tID := taxid.Format(ctx, party.TaxID)
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div class=\"tax-id\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if taxIDCodeIncludesCountry(party) {
-				templ_7745c5c3_Err = t.T(".tax_id_no_country", i18n.M{"label": taxIDLabel(ctx, party), "code": taxIDCode(party)}).Render(ctx, templ_7745c5c3_Buffer)
+			if tID.Country == "" {
+				templ_7745c5c3_Err = t.T(".tax_id_no_country", i18n.M{"label": tID.Label, "code": tID.Code}).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = t.T(".tax_id", i18n.M{"label": taxIDLabel(ctx, party), "country": party.TaxID.Country.String(), "code": taxIDCode(party)}).Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = t.T(".tax_id", i18n.M{"label": tID.Label, "country": tID.Country, "code": tID.Code}).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -544,7 +545,7 @@ func registration(reg *org.Registration) templ.Component {
 					var templ_7745c5c3_Var14 string
 					templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(reg.Office)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 123, Col: 18}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 126, Col: 18}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 					if templ_7745c5c3_Err != nil {
@@ -647,7 +648,7 @@ func registration(reg *org.Registration) templ.Component {
 					var templ_7745c5c3_Var15 string
 					templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(reg.Other)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 158, Col: 17}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 161, Col: 17}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 					if templ_7745c5c3_Err != nil {
@@ -717,7 +718,7 @@ func partyExtensions(party *org.Party) templ.Component {
 				var templ_7745c5c3_Var17 string
 				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(txt)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 175, Col: 9}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/org/party.templ`, Line: 178, Col: 9}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 				if templ_7745c5c3_Err != nil {
@@ -801,54 +802,6 @@ func showIdentity(ident *org.Identity) bool {
 
 func showTaxID(party *org.Party) bool {
 	return party.TaxID != nil && party.TaxID.Code != cbc.CodeEmpty
-}
-
-func taxIDLabel(ctx context.Context, party *org.Party) string {
-	tID := party.TaxID
-	switch tID.Country {
-	case "AR":
-		return "CUIT"
-	case "SG":
-		return "GST Reg No."
-	case "DE":
-		return "USt-IdNr."
-	case "ES":
-		return "NIF"
-	case "CO":
-		return "NIT"
-	case "MX":
-		return "RFC"
-	case "FR":
-		return "TVA"
-	case "PT":
-		return "NIF"
-	case "IT":
-		return "P.IVA"
-	default:
-		return i18n.T(ctx, ".labels.default")
-	}
-}
-
-func taxIDCode(party *org.Party) string {
-	tID := party.TaxID
-	code := tID.Code.String()
-	switch tID.Country {
-	case "CO":
-		return co.FormatTaxIDCode(code)
-	default:
-		if taxIDCodeIncludesCountry(party) {
-			return tID.Country.String() + code
-		}
-		return code
-	}
-}
-
-// taxIDCodeIncludesCountry reports whether the country prefix is an
-// integral part of the tax ID code, in which case it is prepended to
-// the code and not shown separately in parentheses. The German
-// USt-IdNr., for example, is only valid with the "DE" prefix.
-func taxIDCodeIncludesCountry(party *org.Party) bool {
-	return party.TaxID.Country == "DE"
 }
 
 func mapPartyExtension(ctx context.Context, k cbc.Key, v cbc.Code) string {

--- a/components/regimes/co/co.go
+++ b/components/regimes/co/co.go
@@ -30,17 +30,3 @@ func titleKey(doc internal.Document) string {
 	}
 	return ""
 }
-
-// FormatTaxIDCode formats a Colombian tax ID code.
-func FormatTaxIDCode(taxID string) string {
-	dv := taxID[len(taxID)-1:]
-	nitChars := taxID[:len(taxID)-1]
-	nit := ""
-	for i, c := range nitChars {
-		if i%3 == 0 && i != 0 {
-			nit += "."
-		}
-		nit += string(c)
-	}
-	return nit + "-" + dv
-}

--- a/components/taxid/taxid.go
+++ b/components/taxid/taxid.go
@@ -1,0 +1,166 @@
+// Package taxid formats tax identities according to the way each country
+// officially presents them on invoices.
+package taxid
+
+import (
+	"context"
+	"strings"
+
+	"github.com/invopop/ctxi18n/i18n"
+	"github.com/invopop/gobl.html/internal"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/tax"
+)
+
+// labelKeyPrefix is the absolute translation key under which the names of
+// the tax identities are kept. Keys are absolute so that the labels resolve
+// wherever a tax identity is rendered, regardless of the current scope.
+const labelKeyPrefix = "org.party.labels."
+
+// Formatted holds a tax identity broken down into the parts needed to
+// present it.
+type Formatted struct {
+	// Label names the identifier as it is known locally, e.g. "USt-IdNr.".
+	Label string
+	// Code is the identifier laid out with the separators used locally, and
+	// prefixed with the country code when Country is empty.
+	Code string
+	// Country is the tax country code to show alongside the code, and is
+	// empty when the prefix already forms part of Code.
+	Country string
+}
+
+// rule describes how a country's tax identity is officially presented.
+// The name of the identifier is not held here but translated, see label.
+type rule struct {
+	// prefixed indicates that the country code forms part of the identifier
+	// itself, and so is always written joined to the code, both at home and
+	// abroad.
+	prefixed bool
+	// separator goes between the country code and the code when prefixed.
+	separator string
+	// format lays the code out with the separators used locally.
+	format func(code string) string
+}
+
+// rules defines the country specific presentation of tax identities. GOBL
+// never stores the country code inside `tax_id.code`, so a country whose
+// official identifier includes the prefix is marked as `prefixed` here.
+//
+// The remaining countries write their national identifier without a prefix.
+// They only gain one when it is used as an intra-community VAT
+// identification number, which is handled by intraCommunity below.
+var rules = map[l10n.TaxCountryCode]rule{
+	l10n.AT.Tax(): {prefixed: true},
+	l10n.CH.Tax(): {prefixed: true, format: formatCH},
+	l10n.CO.Tax(): {format: formatCO},
+	l10n.DE.Tax(): {prefixed: true},
+	l10n.FR.Tax(): {prefixed: true},
+	l10n.IE.Tax(): {prefixed: true},
+	l10n.NL.Tax(): {prefixed: true},
+	l10n.NO.Tax(): {prefixed: true, separator: " ", format: formatNO},
+	l10n.SE.Tax(): {prefixed: true},
+}
+
+// Format prepares a tax identity for presentation, using the official
+// representation of the country that issued it. The document being rendered
+// is taken from the context to determine whether the identity is acting as
+// an intra-community VAT identification number.
+func Format(ctx context.Context, tID *tax.Identity) Formatted {
+	if tID == nil {
+		return Formatted{}
+	}
+	r := rules[tID.Country]
+
+	f := Formatted{
+		Label: label(ctx, tID.Country),
+		Code:  tID.Code.String(),
+	}
+	if r.format != nil {
+		f.Code = r.format(f.Code)
+	}
+	if r.prefixed || intraCommunity(ctx, tID) {
+		f.Code = tID.Country.String() + r.separator + f.Code
+	} else {
+		f.Country = tID.Country.String()
+	}
+	return f
+}
+
+// label provides the name by which the identifier is known, e.g. "USt-IdNr."
+// for Germany. Names are kept in the locales so that they can be adapted to
+// the language the document is rendered in, and countries without one of
+// their own fall back to the generic label.
+func label(ctx context.Context, country l10n.TaxCountryCode) string {
+	key := labelKeyPrefix + strings.ToLower(country.String())
+	if i18n.Has(ctx, key) {
+		return i18n.T(ctx, key)
+	}
+	return i18n.T(ctx, labelKeyPrefix+"default")
+}
+
+// intraCommunity reports whether the tax identity is being used as an
+// intra-community VAT identification number, which happens when the document
+// records a supply between two different EU member states. Article 226 of the
+// VAT Directive requires the VAT identification numbers of both parties in
+// that case, and those are always written with their country prefix.
+func intraCommunity(ctx context.Context, tID *tax.Identity) bool {
+	doc := internal.DocumentFrom(ctx)
+	if doc == nil {
+		return false
+	}
+	sup, cus := doc.GetSupplier(), doc.GetCustomer()
+	if sup == nil || cus == nil {
+		return false
+	}
+	supID, cusID := sup.TaxID, cus.TaxID
+	if supID == nil || cusID == nil || supID.Country == cusID.Country {
+		return false
+	}
+	date := doc.GetIssueDate()
+	if date.IsZero() {
+		date = cal.Today()
+	}
+	// The identity itself is checked as well so that a third party from
+	// outside the union, such as a delivery receiver, keeps its national
+	// format.
+	return supID.InEU(date) && cusID.InEU(date) && tID.InEU(date)
+}
+
+// formatCO groups the Colombian NIT in threes and splits off the trailing
+// "dígito de verificación", e.g. "9015852843" becomes "901.585.284-3".
+func formatCO(code string) string {
+	if len(code) < 2 {
+		return code
+	}
+	digits, dv := code[:len(code)-1], code[len(code)-1:]
+	nit := new(strings.Builder)
+	for i, c := range digits {
+		if i%3 == 0 && i != 0 {
+			nit.WriteString(".")
+		}
+		nit.WriteRune(c)
+	}
+	return nit.String() + "-" + dv
+}
+
+// formatCH lays out the Swiss UID as "CHE-123.456.789". GOBL stores the
+// identifier without the "CH" prefix, so the leading "E" and the dash that
+// follows it belong to the code here.
+func formatCH(code string) string {
+	digits := strings.TrimPrefix(code, "E")
+	if len(digits) != 9 {
+		return code
+	}
+	return "E-" + digits[0:3] + "." + digits[3:6] + "." + digits[6:9]
+}
+
+// formatNO separates the "MVA" suffix that marks a Norwegian organisation
+// number as registered for VAT, e.g. "NO 123456785 MVA".
+func formatNO(code string) string {
+	if base, ok := strings.CutSuffix(code, "MVA"); ok {
+		return base + " MVA"
+	}
+	return code
+}

--- a/components/taxid/taxid_test.go
+++ b/components/taxid/taxid_test.go
@@ -1,0 +1,170 @@
+package taxid
+
+import (
+	"context"
+	"testing"
+
+	"github.com/invopop/ctxi18n/i18n"
+	"github.com/invopop/gobl.html/internal"
+	"github.com/invopop/gobl.html/locales"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+)
+
+// localized prepares a context with the locales loaded the same way as
+// goblhtml does, with "en" merged into every other locale.
+func localized(t *testing.T, code string) context.Context {
+	t.Helper()
+	locs := new(i18n.Locales)
+	if err := locs.LoadWithDefault(locales.Content, "en"); err != nil {
+		t.Fatal(err)
+	}
+	l := locs.Match(code)
+	if l == nil {
+		t.Fatalf("unknown locale %q", code)
+	}
+	return l.WithContext(context.Background())
+}
+
+func TestFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      *tax.Identity
+		label   string
+		code    string
+		country string
+	}{
+		{
+			name:    "national identifier without prefix",
+			id:      &tax.Identity{Country: "ES", Code: "B98602642"},
+			label:   "NIF",
+			code:    "B98602642",
+			country: "ES",
+		},
+		{
+			name:  "prefix part of the official identifier",
+			id:    &tax.Identity{Country: "DE", Code: "111111125"},
+			label: "USt-IdNr.",
+			code:  "DE111111125",
+		},
+		{
+			name:  "French VAT number",
+			id:    &tax.Identity{Country: "FR", Code: "44732829320"},
+			label: "TVA",
+			code:  "FR44732829320",
+		},
+		{
+			name: "Swiss UID grouping",
+			id:   &tax.Identity{Country: "CH", Code: "E123456789"},
+			code: "CHE-123.456.789",
+		},
+		{
+			name: "Norwegian VAT suffix",
+			id:   &tax.Identity{Country: "NO", Code: "123456785MVA"},
+			code: "NO 123456785 MVA",
+		},
+		{
+			name:    "Colombian NIT grouping",
+			id:      &tax.Identity{Country: "CO", Code: "9015852843"},
+			label:   "NIT",
+			code:    "901.585.284-3",
+			country: "CO",
+		},
+		{
+			name:    "Greek identities use the EL tax country code",
+			id:      &tax.Identity{Country: "EL", Code: "177472438"},
+			code:    "177472438",
+			country: "EL",
+		},
+	}
+
+	for _, ts := range tests {
+		t.Run(ts.name, func(t *testing.T) {
+			f := Format(localized(t, "en"), ts.id)
+			if ts.label != "" && f.Label != ts.label {
+				t.Errorf("label: got %q, want %q", f.Label, ts.label)
+			}
+			if f.Code != ts.code {
+				t.Errorf("code: got %q, want %q", f.Code, ts.code)
+			}
+			if f.Country != ts.country {
+				t.Errorf("country: got %q, want %q", f.Country, ts.country)
+			}
+		})
+	}
+}
+
+func TestFormatNil(t *testing.T) {
+	if f := Format(localized(t, "en"), nil); f != (Formatted{}) {
+		t.Errorf("expected empty result, got %+v", f)
+	}
+}
+
+func TestFormatLabelLocalized(t *testing.T) {
+	// Countries without a name of their own take the generic label of the
+	// language the document is rendered in.
+	generic := &tax.Identity{Country: "SE", Code: "123456789001"}
+	if l := Format(localized(t, "en"), generic).Label; l != "TIN" {
+		t.Errorf("en: got %q", l)
+	}
+	if l := Format(localized(t, "es"), generic).Label; l != "Código fiscal" {
+		t.Errorf("es: got %q", l)
+	}
+
+	// Names defined for a country are used in every language until a locale
+	// provides its own.
+	named := &tax.Identity{Country: "DE", Code: "111111125"}
+	if l := Format(localized(t, "es"), named).Label; l != "USt-IdNr." {
+		t.Errorf("es: got %q", l)
+	}
+}
+
+func TestFormatIntraCommunity(t *testing.T) {
+	invoice := func(supplier, customer string) context.Context {
+		inv := &bill.Invoice{
+			IssueDate: cal.MakeDate(2025, 1, 15),
+			Supplier:  &org.Party{TaxID: mustParse(t, supplier)},
+			Customer:  &org.Party{TaxID: mustParse(t, customer)},
+		}
+		return internal.WithDocument(localized(t, "en"), internal.DocumentFor(inv))
+	}
+
+	t.Run("supply between member states", func(t *testing.T) {
+		ctx := invoice("ESB98602642", "NL000099995B57")
+		if f := Format(ctx, mustParse(t, "ESB98602642")); f.Code != "ESB98602642" || f.Country != "" {
+			t.Errorf("got %+v", f)
+		}
+	})
+
+	t.Run("domestic supply keeps the national format", func(t *testing.T) {
+		ctx := invoice("ESB98602642", "ESB63272603")
+		if f := Format(ctx, mustParse(t, "ESB98602642")); f.Code != "B98602642" || f.Country != "ES" {
+			t.Errorf("got %+v", f)
+		}
+	})
+
+	t.Run("export outside the union keeps the national format", func(t *testing.T) {
+		ctx := invoice("ESB98602642", "US123456789")
+		if f := Format(ctx, mustParse(t, "ESB98602642")); f.Code != "B98602642" || f.Country != "ES" {
+			t.Errorf("got %+v", f)
+		}
+	})
+
+	t.Run("third party outside the union keeps the national format", func(t *testing.T) {
+		ctx := invoice("ESB98602642", "NL000099995B57")
+		if f := Format(ctx, &tax.Identity{Country: "SG", Code: "199307558M"}); f.Country != "SG" {
+			t.Errorf("got %+v", f)
+		}
+	})
+}
+
+func mustParse(t *testing.T, tin string) *tax.Identity {
+	t.Helper()
+	id, err := tax.ParseIdentity(tin)
+	if err != nil {
+		t.Fatalf("parsing %s: %s", tin, err)
+	}
+	return id
+}

--- a/components/taxid/taxid_test.go
+++ b/components/taxid/taxid_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
+// The Spanish identity is reused across the cases below, in both its
+// national and its intra-community form.
+const (
+	esCode = "B98602642"
+	esTIN  = "ES" + esCode
+)
+
 // localized prepares a context with the locales loaded the same way as
 // goblhtml does, with "en" merged into every other locale.
 func localized(t *testing.T, code string) context.Context {
@@ -38,9 +45,9 @@ func TestFormat(t *testing.T) {
 	}{
 		{
 			name:    "national identifier without prefix",
-			id:      &tax.Identity{Country: "ES", Code: "B98602642"},
+			id:      &tax.Identity{Country: "ES", Code: esCode},
 			label:   "NIF",
-			code:    "B98602642",
+			code:    esCode,
 			country: "ES",
 		},
 		{
@@ -132,28 +139,28 @@ func TestFormatIntraCommunity(t *testing.T) {
 	}
 
 	t.Run("supply between member states", func(t *testing.T) {
-		ctx := invoice("ESB98602642", "NL000099995B57")
-		if f := Format(ctx, mustParse(t, "ESB98602642")); f.Code != "ESB98602642" || f.Country != "" {
+		ctx := invoice(esTIN, "NL000099995B57")
+		if f := Format(ctx, mustParse(t, esTIN)); f.Code != esTIN || f.Country != "" {
 			t.Errorf("got %+v", f)
 		}
 	})
 
 	t.Run("domestic supply keeps the national format", func(t *testing.T) {
-		ctx := invoice("ESB98602642", "ESB63272603")
-		if f := Format(ctx, mustParse(t, "ESB98602642")); f.Code != "B98602642" || f.Country != "ES" {
+		ctx := invoice(esTIN, "ESB63272603")
+		if f := Format(ctx, mustParse(t, esTIN)); f.Code != esCode || f.Country != "ES" {
 			t.Errorf("got %+v", f)
 		}
 	})
 
 	t.Run("export outside the union keeps the national format", func(t *testing.T) {
-		ctx := invoice("ESB98602642", "US123456789")
-		if f := Format(ctx, mustParse(t, "ESB98602642")); f.Code != "B98602642" || f.Country != "ES" {
+		ctx := invoice(esTIN, "US123456789")
+		if f := Format(ctx, mustParse(t, esTIN)); f.Code != esCode || f.Country != "ES" {
 			t.Errorf("got %+v", f)
 		}
 	})
 
 	t.Run("third party outside the union keeps the national format", func(t *testing.T) {
-		ctx := invoice("ESB98602642", "NL000099995B57")
+		ctx := invoice(esTIN, "NL000099995B57")
 		if f := Format(ctx, &tax.Identity{Country: "SG", Code: "199307558M"}); f.Country != "SG" {
 			t.Errorf("got %+v", f)
 		}

--- a/examples/out/de-choruspro-invoice.html
+++ b/examples/out/de-choruspro-invoice.html
@@ -122,7 +122,7 @@
                     Email: email@sample.com
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 44732829320
+                    TVA: FR44732829320
                   </div>
                   <div class="identity">
                     SIRET: 73282932012345

--- a/examples/out/fr-choruspro-invoice.html
+++ b/examples/out/fr-choruspro-invoice.html
@@ -102,7 +102,7 @@
                     Email: billing@example.com
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 44732829320
+                    TVA: FR44732829320
                   </div>
                   <div class="identity">
                     SIRET: 73282932012345
@@ -128,7 +128,7 @@
                     Email: email@sample.com
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 39356000000
+                    TVA: FR39356000000
                   </div>
                   <div class="identity">
                     SIRET: 35600000012345

--- a/examples/out/fr-ctc-credit-note.html
+++ b/examples/out/fr-ctc-credit-note.html
@@ -110,7 +110,7 @@
                     Email: facturation@fournisseur.fr
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 44732829320
+                    TVA: FR44732829320
                   </div>
                   <div class="identity">
                     SIREN: 732829320
@@ -136,7 +136,7 @@
                     Email: comptabilite@client.fr
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 39356000000
+                    TVA: FR39356000000
                   </div>
                   <div class="identity">
                     SIREN: 356000000

--- a/examples/out/fr-ctc-invoice-advance.html
+++ b/examples/out/fr-ctc-invoice-advance.html
@@ -99,7 +99,7 @@
                     Email: facturation@fournisseur.fr
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 44732829320
+                    TVA: FR44732829320
                   </div>
                   <div class="identity">
                     SIREN: 732829320
@@ -125,7 +125,7 @@
                     Email: comptabilite@client.fr
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 39356000000
+                    TVA: FR39356000000
                   </div>
                   <div class="identity">
                     SIREN: 356000000

--- a/examples/out/fr-ctc-invoice-b2b.html
+++ b/examples/out/fr-ctc-invoice-b2b.html
@@ -110,7 +110,7 @@
                     Email: facturation@fournisseur.fr
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 44732829320
+                    TVA: FR44732829320
                   </div>
                   <div class="identity">
                     SIREN: 732829320
@@ -139,7 +139,7 @@
                     Email: comptabilite@client.fr
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 39356000000
+                    TVA: FR39356000000
                   </div>
                   <div class="identity">
                     SIREN: 356000000

--- a/examples/out/fr-ctc-invoice-b2bint.html
+++ b/examples/out/fr-ctc-invoice-b2bint.html
@@ -99,7 +99,7 @@
                     Email: facturation@fournisseur.fr
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 44732829320
+                    TVA: FR44732829320
                   </div>
                   <div class="identity">
                     SIREN: 732829320

--- a/examples/out/fr-facturx-invoice.html
+++ b/examples/out/fr-facturx-invoice.html
@@ -99,7 +99,7 @@
                     Email: billing@example.com
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 44732829320
+                    TVA: FR44732829320
                   </div>
                 </div>
               </div>
@@ -122,7 +122,7 @@
                     Email: email@sample.com
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 39356000000
+                    TVA: FR39356000000
                   </div>
                 </div>
               </div>

--- a/examples/out/fr-invoice-delivery.html
+++ b/examples/out/fr-invoice-delivery.html
@@ -99,7 +99,7 @@
                     Email: billing@example.com
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 44732829320
+                    TVA: FR44732829320
                   </div>
                 </div>
               </div>
@@ -122,7 +122,7 @@
                     Email: email@sample.com
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 39356000000
+                    TVA: FR39356000000
                   </div>
                 </div>
               </div>

--- a/examples/out/fr-invoice-units.fr.html
+++ b/examples/out/fr-invoice-units.fr.html
@@ -91,7 +91,7 @@
                     Email: billing@example.com
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 44732829320
+                    TVA: FR44732829320
                   </div>
                 </div>
               </div>
@@ -111,7 +111,7 @@
                     </span>
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 39356000000
+                    TVA: FR39356000000
                   </div>
                 </div>
               </div>

--- a/examples/out/fr-invoice.html
+++ b/examples/out/fr-invoice.html
@@ -99,7 +99,7 @@
                     Email: billing@example.com
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 44732829320
+                    TVA: FR44732829320
                   </div>
                 </div>
               </div>
@@ -122,7 +122,7 @@
                     Email: email@sample.com
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 39356000000
+                    TVA: FR39356000000
                   </div>
                 </div>
               </div>

--- a/examples/out/fr-self-billed-invoice.html
+++ b/examples/out/fr-self-billed-invoice.html
@@ -102,7 +102,7 @@
                     Email: billing@example.com
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 44732829320
+                    TVA: FR44732829320
                   </div>
                 </div>
               </div>
@@ -125,7 +125,7 @@
                     Email: email@sample.com
                   </div>
                   <div class="tax-id">
-                    TVA: (FR) 39356000000
+                    TVA: FR39356000000
                   </div>
                 </div>
               </div>

--- a/examples/out/invoice-es-reverse-charge.html
+++ b/examples/out/invoice-es-reverse-charge.html
@@ -91,7 +91,7 @@
                     Email: billing@example.com
                   </div>
                   <div class="tax-id">
-                    NIF: (ES) B98602642
+                    NIF: ESB98602642
                   </div>
                 </div>
               </div>
@@ -106,7 +106,7 @@
                     Sample Consumer
                   </div>
                   <div class="tax-id">
-                    TIN: (NL) 000099995B57
+                    TIN: NL000099995B57
                   </div>
                 </div>
               </div>

--- a/goblhtml.go
+++ b/goblhtml.go
@@ -230,6 +230,12 @@ func Render(ctx context.Context, env *gobl.Envelope, opts ...Option) ([]byte, er
 
 	ctx = internal.WithOptions(ctx, o)
 
+	// Make the document available to components that only receive a part of
+	// it, such as the party details.
+	if d := internal.ExtractDocumentFrom(env); d != nil {
+		ctx = internal.WithDocument(ctx, d)
+	}
+
 	if o.AdjustmentMode {
 		switch doc := env.Extract().(type) {
 		case *bill.Invoice:

--- a/internal/document.go
+++ b/internal/document.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"context"
+
 	"github.com/invopop/gobl"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
@@ -23,6 +25,24 @@ type Document interface {
 	GetCurrency() currency.Code
 	GetExt() tax.Extensions
 	GetPreceding() []*org.DocumentRef
+}
+
+type documentKey string
+
+const docKey documentKey = "doc"
+
+// WithDocument stores the document being rendered in the context so that
+// components which only receive a fragment of it, such as the party details,
+// can still take the document as a whole into account.
+func WithDocument(ctx context.Context, doc Document) context.Context {
+	return context.WithValue(ctx, docKey, doc)
+}
+
+// DocumentFrom provides the document being rendered from the context, and
+// nil when there is none, as happens when a component is rendered on its own.
+func DocumentFrom(ctx context.Context) Document {
+	doc, _ := ctx.Value(docKey).(Document)
+	return doc
 }
 
 // DocumentFor returns a Document interface for the given document.

--- a/locales/en/app.yml
+++ b/locales/en/app.yml
@@ -244,6 +244,15 @@ en:
       po_box: "P.O. box %{po_box}"
       labels:
         default: "TIN"
+        ar: "CUIT"
+        co: "NIT"
+        de: "USt-IdNr."
+        es: "NIF"
+        fr: "TVA"
+        it: "P.IVA"
+        mx: "RFC"
+        pt: "NIF"
+        sg: "GST Reg No."
       identity: "%{label}: %{code}"
       identity_code: "Identity code"
       identity_labels:


### PR DESCRIPTION
## Why

Tax IDs were rendered as a bare code with the country in parentheses — `NIF: (ES) B98602642` — with one hardcoded exception for Germany, whose USt-IdNr. is only valid with the `DE` prefix.

Germany is not alone. In AT, CH, DE, FR, IE, NL, NO and SE the country code is genuinely part of the national identifier. GOBL strips it on normalization (`tax.NormalizeIdentity` trims the country prefix, since the country lives in `tax_id.country`), so it has to be put back when presenting the identity. Separately, for most EU regimes the prefix belongs to the *intra-community* VAT identification number rather than the domestic one — art. 226(3)(4) of the VAT Directive requires both parties' VAT identification numbers on a cross-border supply, and those always carry the prefix.

## What changed

**New `components/taxid` package.** One table of country rules replaces the German special case:

```go
var rules = map[l10n.TaxCountryCode]rule{
	l10n.AT.Tax(): {prefixed: true},
	l10n.CH.Tax(): {prefixed: true, format: formatCH},
	l10n.CO.Tax(): {format: formatCO},
	...
}
```

`Format(ctx, tID)` returns `Formatted{Label, Code, Country}`, where an empty `Country` means the prefix belongs inside the code. Three cases:

1. **Prefix is part of the national identifier** — AT, CH, DE, FR, IE, NL, NO, SE. Always joined.
2. **Intra-community** — supplier and customer in two *different* EU member states, checked against the issue date via `Identity.InEU`. The identity itself is EU-checked too, so a non-EU third party on an intra-EU invoice keeps its national form.
3. **Otherwise** — the national form, country in parentheses as before.

Local layouts live alongside: CO (`901.585.284-3`), CH (`CHE-123.456.789`), NO (`NO 123456785 MVA`).

**Document in the rendering context.** `org.Party` only ever receives a party, so the intra-community check had nothing to work with. Added `internal.WithDocument` / `internal.DocumentFrom`, set once in `Render`. It degrades to the national form when absent, so `org.Party` rendered standalone still works.

**Labels are now translatable.** Identifier names moved out of Go into `org.party.labels` in the locales, keyed by lowercased tax country code and falling back to the existing `default`:

```yaml
labels:
  default: "TIN"
  ar: "CUIT"
  de: "USt-IdNr."
  ...
```

Keys are absolute rather than scope-relative, so they resolve wherever a tax identity is rendered.

**Call sites.** `party.templ` loses the `taxIDLabel` / `taxIDCode` / `taxIDCodeIncludesCountry` trio for a single `taxid.Format` call. The "on behalf of" line seller in `lines.templ` now uses the same formatter instead of printing a bare code.

## Output changes

Only four distinct lines moved across the whole example set:

```
- NIF: (ES) B98602642      + NIF: ESB98602642        (ES→NL, intra-community)
- TIN: (NL) 000099995B57   + TIN: NL000099995B57
- TVA: (FR) 44732829320    + TVA: FR44732829320      (FR prefix is integral)
- TVA: (FR) 39356000000    + TVA: FR39356000000
```

`examples/out` is regenerated.

## For the reviewer

- **Breaking:** `co.FormatTaxIDCode` was removed from `components/regimes/co`. It was only used by `party.templ`; the logic now lives in `components/taxid` next to the Swiss and Norwegian layouts.
- **Only English labels are populated.** Every other locale inherits them via `LoadWithDefault(…, "en")`, so nothing regressed, but `GST Reg No.` is English prose and a native speaker should decide its form in the other languages. Those are one-line additions per locale.
- **Judgement calls worth a second opinion:** the prefixed set follows the "prefix is genuinely part of the national identifier" list, which puts NO in and leaves GB and GR/EL out — GB VAT numbers are often written `GB…` in practice even though it is not required. I also did not add digit grouping beyond CO, CH and NO.

## Tests

New `components/taxid/taxid_test.go` covers each country rule, the nil identity, the domestic / intra-EU / export / non-EU-third-party paths, and label localization (a country with no name of its own picks up the locale's generic label; a named country keeps its name across languages). `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)