### PR TITLE
Add debit-transfer payment method translations

### DIFF
--- a/locales/ar/app.yml
+++ b/locales/ar/app.yml
@@ -134,6 +134,7 @@ ar:
             card+credit: "بطاقة ائتمانية"
             card+debit: "بطاقة خصم"
             credit-transfer: "تحويل بنكي"
+            debit-transfer: "تحويل خصم"
             cash: "نقد"
             direct-debit: "خصم مباشر"
             online: "عبر الإنترنت"

--- a/locales/ca/app.yml
+++ b/locales/ca/app.yml
@@ -134,6 +134,7 @@ ca:
             card+credit: "Targeta de crèdit"
             card+debit: "Targeta de dèbit"
             credit-transfer: "Transferència bancària"
+            debit-transfer: "Transferència de dèbit"
             cash: "Efectiu"
             direct-debit: "Domiciliació bancària"
             online: "En línia"

--- a/locales/da/app.yml
+++ b/locales/da/app.yml
@@ -130,6 +130,7 @@ da:
             card+credit: "Kreditkort"
             card+debit: "Debetkort"
             credit-transfer: "Bankoverførsel"
+            debit-transfer: "Debetoverførsel"
             cash: "Kontant"
             direct-debit: "Direkte debitering"
             online: "Online"

--- a/locales/de/app.yml
+++ b/locales/de/app.yml
@@ -130,6 +130,7 @@ de:
             card+credit: "Kreditkarte"
             card+debit: "Debitkarte"
             credit-transfer: "Banküberweisung"
+            debit-transfer: "Debitüberweisung"
             cash: "Bargeld"
             direct-debit: "Lastschrift"
             online: "Online"

--- a/locales/el/app.yml
+++ b/locales/el/app.yml
@@ -132,6 +132,7 @@ el:
             card+credit: "Πιστωτική κάρτα"
             card+debit: "Χρεωστική κάρτα"
             credit-transfer: "Τραπεζική μεταφορά"
+            debit-transfer: "Χρεωστική μεταφορά"
             cash: "Μετρητά"
             direct-debit: "Άμεση πίστωση"
             online: "Διαδικτυακά"

--- a/locales/en/app.yml
+++ b/locales/en/app.yml
@@ -135,6 +135,7 @@ en:
             card+credit: "Credit card"
             card+debit: "Debit card"
             credit-transfer: "Bank transfer"
+            debit-transfer: "Debit transfer"
             cash: "Cash"
             direct-debit: "Direct debit"
             online: "Online"

--- a/locales/es/app.yml
+++ b/locales/es/app.yml
@@ -134,6 +134,7 @@ es:
             card+credit: "Tarjeta de crédito"
             card+debit: "Tarjeta de débito"
             credit-transfer: "Transferencia bancaria"
+            debit-transfer: "Transferencia de débito"
             cash: "Efectivo"
             direct-debit: "Domiciliación bancaria"
             online: "En línea"

--- a/locales/eu/app.yml
+++ b/locales/eu/app.yml
@@ -134,6 +134,7 @@ eu:
             card+credit: "Kreditu txartela"
             card+debit: "Debitu txartela"
             credit-transfer: "Banku transferentzia"
+            debit-transfer: "Debitu transferentzia"
             cash: "Dirutan"
             direct-debit: "Banku domiziliazioa"
             online: "Linean"

--- a/locales/fr/app.yml
+++ b/locales/fr/app.yml
@@ -121,6 +121,7 @@ fr:
             card+credit: "Carte de crédit"
             card+debit: "Carte de débit"
             credit-transfer: "Virement bancaire"
+            debit-transfer: "Virement de débit"
             cash: "Espèces"
             direct-debit: "Prélèvement automatique"
             online: "En ligne"

--- a/locales/gl/app.yml
+++ b/locales/gl/app.yml
@@ -134,6 +134,7 @@ gl:
             card+credit: "Tarxeta de crédito"
             card+debit: "Tarxeta de débito"
             credit-transfer: "Transferencia bancaria"
+            debit-transfer: "Transferencia de débito"
             cash: "Efectivo"
             direct-debit: "Domiciliación bancaria"
             online: "En liña"

--- a/locales/it/app.yml
+++ b/locales/it/app.yml
@@ -121,6 +121,7 @@ it:
             card+credit: "Carta di credito"
             card+debit: "Carta di debito"
             credit-transfer: "Bonifico bancario"
+            debit-transfer: "Trasferimento di debito"
             cash: "Contanti"
             direct-debit: "Addebito diretto"
             online: "Online"

--- a/locales/nl/app.yml
+++ b/locales/nl/app.yml
@@ -130,6 +130,7 @@ nl:
             card+credit: "Creditcard"
             card+debit: "Debetkaart"
             credit-transfer: "Bankoverschrijving"
+            debit-transfer: "Debetoverboeking"
             cash: "Contant"
             direct-debit: "Automatische incasso"
             online: "Online"

--- a/locales/no/app.yml
+++ b/locales/no/app.yml
@@ -130,6 +130,7 @@ no:
             card+credit: "Kredittkort"
             card+debit: "Debetkort"
             credit-transfer: "Bankoverføring"
+            debit-transfer: "Debetoverføring"
             cash: "Kontant"
             direct-debit: "Direkte debitering"
             online: "Online"

--- a/locales/pl/app.yml
+++ b/locales/pl/app.yml
@@ -130,6 +130,7 @@ pl:
             card+credit: "Karta kredytowa"
             card+debit: "Karta debetowa"
             credit-transfer: "Przelew bankowy"
+            debit-transfer: "Przelew debetowy"
             cash: "Gotówka"
             direct-debit: "Polecenie zapłaty"
             online: "Online"

--- a/locales/pt/app.yml
+++ b/locales/pt/app.yml
@@ -130,6 +130,7 @@ pt:
             card+credit: "Cartão de crédito"
             card+debit: "Cartão de débito"
             credit-transfer: "Transferência bancária"
+            debit-transfer: "Transferência de débito"
             cash: "Dinheiro"
             direct-debit: "Débito direto"
             online: "Online"


### PR DESCRIPTION
The payment methods table rendered a raw !(MISSING: ...) marker for documents using the debit-transfer means key, as no locale defined it.