### PR TITLE
Add Finnish debit-transfer payment method translation

### DIFF
--- a/locales/fi/app.yml
+++ b/locales/fi/app.yml
@@ -131,6 +131,7 @@ fi:
             card+credit: "Luottokortti"
             card+debit: "Debit-kortti"
             credit-transfer: "Tilisiirto"
+            debit-transfer: "Veloitussiirto"
             cash: "Käteinen"
             direct-debit: "Suoraveloitus"
             online: "Verkkomaksu"


### PR DESCRIPTION
## What changed

Adds the missing `debit-transfer` payment method translation to the Finnish locale (`locales/fi/app.yml`) as `"Veloitussiirto"`, placed after `credit-transfer` to match the key order used in the other locales.

## Why

#144 added the `debit-transfer` key to all locales except Finnish (which was merged separately in #142), so `TestLocaleKeyCoverage/fi` fails on main.

## Notes for reviewers

The `methods` block in the Finnish file is defined once and shared via a YAML anchor (`*payment_instructions`), so this single line covers all `billing.*.payment.instructions.methods.debit-transfer` scopes. `go test ./locales/...` passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)