### PR TITLE
Fix nil-pointer panic when invoice totals have an advance but no due

### DIFF
--- a/components/bill/totals.templ
+++ b/components/bill/totals.templ
@@ -170,14 +170,16 @@ templ totalsDueRows(inv *bill.Invoice, totals *bill.Totals) {
 				</td>
 			</tr>
 		}
-		<tr class="due strong">
-			<th>
-				@t.T(".due_sum")
-			</th>
-			<td>
-				@t.LM(*totals.Due)
-			</td>
-		</tr>
+		if totals.Due != nil {
+			<tr class="due strong">
+				<th>
+					@t.T(".due_sum")
+				</th>
+				<td>
+					@t.LM(*totals.Due)
+				</td>
+			</tr>
+		}
 	}
 }
 

--- a/components/bill/totals_templ.go
+++ b/components/bill/totals_templ.go
@@ -472,25 +472,31 @@ func totalsDueRows(inv *bill.Invoice, totals *bill.Totals) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, " <tr class=\"due strong\"><th>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = t.T(".due_sum").Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</th><td>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = t.LM(*totals.Due).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</td></tr>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
+			if totals.Due != nil {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<tr class=\"due strong\"><th>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = t.T(".due_sum").Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</th><td>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = t.LM(*totals.Due).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</td></tr>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
The totalsDueRows template rendered the "amount due" row whenever an advance was present, but dereferenced *totals.Due unconditionally. An invoice whose stored totals carry an advance without a due (e.g. a fully prepaid invoice whose zero due was omitted) crashed the entire render with a nil-pointer dereference. Guard the row with a nil check on totals.Due.