### PR TITLE
Update PL KSeF example to current favat stamp names

### DIFF
--- a/examples/out/pl-ksef-invoice.html
+++ b/examples/out/pl-ksef-invoice.html
@@ -319,7 +319,7 @@
               </div>
               <div class="text">
                 <div class="ksef-id">
-                  OFFLINE
+                  ID: 1234567788-20240404-D1984449A6BC-02
                 </div>
               </div>
             </section>

--- a/examples/pl-ksef-invoice.json
+++ b/examples/pl-ksef-invoice.json
@@ -8,12 +8,8 @@
 		},
 		"stamps": [
 			{
-				"prv": "favat-id",
+				"prv": "favat-ksef-number",
 				"val": "1234567788-20240404-D1984449A6BC-02"
-			},
-			{
-				"prv": "favat-hash",
-				"val": "8KCfB1Sa5Jc4Gg6ctK4HKdwnRwK+dxT1ScymF6m5d18="
 			},
 			{
 				"prv": "favat-qr",


### PR DESCRIPTION
## What changed

- Renamed the `favat-id` stamp to `favat-ksef-number` in `examples/pl-ksef-invoice.json`, matching `favat.StampKSeFNumber` in the current gobl `pl/favat` addon.
- Removed the `favat-hash` stamp, which no longer exists in the addon (the hash value is already embedded in the `favat-qr` verification URL).
- Regenerated `examples/out/pl-ksef-invoice.html` via `go test -run TestGOBLRenderExamples -update`.

## Why

`components/regimes/pl/ksef.templ` only recognizes the current stamp names, so the rendered example showed `OFFLINE` instead of the KSeF number. It now renders `ID: 1234567788-20240404-D1984449A6BC-02` next to the QR code.

## Notes for reviewers

- The envelope's signature was left untouched. It was already stale (its payload references even older `ksef-*` stamp names and a different digest), `Envelope.Validate()` doesn't verify signatures, and the digest only covers the document — so renaming header stamps doesn't invalidate anything the tests check. Only MX templates depend on signatures for rendering.
- Full `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)