### PR TITLE
Assume a single bare due date covers the full payable amount

### DIFF
--- a/components/bill/order.templ
+++ b/components/bill/order.templ
@@ -230,7 +230,7 @@ templ orderPaymentDetails(ord *bill.Order) {
 					@paymentInstructions(ord.Payment.Instructions)
 				}
 				if ord.Payment.Terms != nil {
-					@paymentTerms(ord.Payment.Terms)
+					@paymentTerms(ord.Payment.Terms, ord.Totals)
 				}
 			</section>
 		}

--- a/components/bill/order_templ.go
+++ b/components/bill/order_templ.go
@@ -745,7 +745,7 @@ func orderPaymentDetails(ord *bill.Order) templ.Component {
 					}
 				}
 				if ord.Payment.Terms != nil {
-					templ_7745c5c3_Err = paymentTerms(ord.Payment.Terms).Render(ctx, templ_7745c5c3_Buffer)
+					templ_7745c5c3_Err = paymentTerms(ord.Payment.Terms, ord.Totals).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}

--- a/components/bill/payment_details.templ
+++ b/components/bill/payment_details.templ
@@ -8,6 +8,7 @@ import (
 	"github.com/invopop/gobl.html/internal"
 	"github.com/invopop/gobl.html/components/t"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/pay"
 )
 
@@ -22,7 +23,7 @@ templ paymentDetails(inv *bill.Invoice) {
 					@paymentInstructions(inv.Payment.Instructions)
 				}
 				if inv.Payment.Terms != nil {
-					@paymentTerms(inv.Payment.Terms)
+					@paymentTerms(inv.Payment.Terms, inv.Totals)
 				}
 			</section>
 		}
@@ -182,7 +183,7 @@ templ paymentCreditTransferRow(ct *pay.CreditTransfer) {
 	</div>
 }
 
-templ paymentTerms(terms *pay.Terms) {
+templ paymentTerms(terms *pay.Terms, totals *bill.Totals) {
 	@t.Scope(".terms") {
 		<ul class="terms">
 			if terms.Key != "" {
@@ -211,7 +212,7 @@ templ paymentTerms(terms *pay.Terms) {
 						@t.N(".due_dates", len(terms.DueDates))
 					</span>
 					<span class="value">
-						@paymentDueDates(terms)
+						@paymentDueDates(terms, totals)
 					</span>
 				</li>
 			}
@@ -219,10 +220,10 @@ templ paymentTerms(terms *pay.Terms) {
 	}
 }
 
-templ paymentDueDates(terms *pay.Terms) {
+templ paymentDueDates(terms *pay.Terms, totals *bill.Totals) {
 	<table class="due-dates">
 		<tbody>
-			for _, dd := range terms.DueDates {
+			for _, dd := range displayDueDates(terms, totals) {
 				<tr>
 					<td class="date">
 						if dd.Date != nil {
@@ -244,6 +245,23 @@ templ paymentDueDates(terms *pay.Terms) {
 			}
 		</tbody>
 	</table>
+}
+
+// displayDueDates returns the due dates to render, assuming a single due date
+// without an explicit amount or percent covers 100% of the payable total.
+func displayDueDates(terms *pay.Terms, totals *bill.Totals) []*pay.DueDate {
+	dds := terms.DueDates
+	if len(dds) != 1 || dds[0] == nil || totals == nil {
+		return dds
+	}
+	dd := dds[0]
+	if !dd.Amount.IsZero() || dd.Percent != nil {
+		return dds
+	}
+	full := *dd
+	full.Percent = num.NewPercentage(1, 0)
+	full.Amount = totals.Payable
+	return []*pay.DueDate{&full}
 }
 
 func showPayments(inv *bill.Invoice) bool {

--- a/components/bill/payment_details_templ.go
+++ b/components/bill/payment_details_templ.go
@@ -16,6 +16,7 @@ import (
 	"github.com/invopop/gobl.html/components/t"
 	"github.com/invopop/gobl.html/internal"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/pay"
 )
 
@@ -72,7 +73,7 @@ func paymentDetails(inv *bill.Invoice) templ.Component {
 					}
 				}
 				if inv.Payment.Terms != nil {
-					templ_7745c5c3_Err = paymentTerms(inv.Payment.Terms).Render(ctx, templ_7745c5c3_Buffer)
+					templ_7745c5c3_Err = paymentTerms(inv.Payment.Terms, inv.Totals).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -145,7 +146,7 @@ func paymentInstructions(inst *pay.Instructions) templ.Component {
 				var templ_7745c5c3_Var5 string
 				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(pm)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 41, Col: 10}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 42, Col: 10}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 				if templ_7745c5c3_Err != nil {
@@ -172,7 +173,7 @@ func paymentInstructions(inst *pay.Instructions) templ.Component {
 				var templ_7745c5c3_Var6 string
 				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(inst.Ref.String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 51, Col: 25}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 52, Col: 25}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
@@ -467,7 +468,7 @@ func paymentOnlineRow(ol *pay.Online) templ.Component {
 		var templ_7745c5c3_Var10 templ.SafeURL
 		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(ol.URL))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 146, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 147, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
@@ -481,7 +482,7 @@ func paymentOnlineRow(ol *pay.Online) templ.Component {
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(ol.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 148, Col: 13}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 149, Col: 13}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -491,7 +492,7 @@ func paymentOnlineRow(ol *pay.Online) templ.Component {
 			var templ_7745c5c3_Var12 string
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(ol.URL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 150, Col: 11}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 151, Col: 11}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -609,7 +610,7 @@ func paymentCreditTransferRow(ct *pay.CreditTransfer) templ.Component {
 	})
 }
 
-func paymentTerms(terms *pay.Terms) templ.Component {
+func paymentTerms(terms *pay.Terms, totals *bill.Totals) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -662,7 +663,7 @@ func paymentTerms(terms *pay.Terms) templ.Component {
 				var templ_7745c5c3_Var16 string
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(paymentTermsKeyName(ctx, terms))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 194, Col: 39}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 195, Col: 39}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 				if templ_7745c5c3_Err != nil {
@@ -689,7 +690,7 @@ func paymentTerms(terms *pay.Terms) templ.Component {
 				var templ_7745c5c3_Var17 string
 				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(terms.Notes)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 204, Col: 19}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 205, Col: 19}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 				if templ_7745c5c3_Err != nil {
@@ -713,7 +714,7 @@ func paymentTerms(terms *pay.Terms) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = paymentDueDates(terms).Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = paymentDueDates(terms, totals).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -736,7 +737,7 @@ func paymentTerms(terms *pay.Terms) templ.Component {
 	})
 }
 
-func paymentDueDates(terms *pay.Terms) templ.Component {
+func paymentDueDates(terms *pay.Terms, totals *bill.Totals) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -761,7 +762,7 @@ func paymentDueDates(terms *pay.Terms) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		for _, dd := range terms.DueDates {
+		for _, dd := range displayDueDates(terms, totals) {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<tr><td class=\"date\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -779,7 +780,7 @@ func paymentDueDates(terms *pay.Terms) templ.Component {
 			var templ_7745c5c3_Var19 string
 			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(dd.Notes)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 233, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/bill/payment_details.templ`, Line: 234, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {
@@ -822,6 +823,23 @@ func paymentDueDates(terms *pay.Terms) templ.Component {
 		}
 		return nil
 	})
+}
+
+// displayDueDates returns the due dates to render, assuming a single due date
+// without an explicit amount or percent covers 100% of the payable total.
+func displayDueDates(terms *pay.Terms, totals *bill.Totals) []*pay.DueDate {
+	dds := terms.DueDates
+	if len(dds) != 1 || dds[0] == nil || totals == nil {
+		return dds
+	}
+	dd := dds[0]
+	if !dd.Amount.IsZero() || dd.Percent != nil {
+		return dds
+	}
+	full := *dd
+	full.Percent = num.NewPercentage(1, 0)
+	full.Amount = totals.Payable
+	return []*pay.DueDate{&full}
 }
 
 func showPayments(inv *bill.Invoice) bool {


### PR DESCRIPTION
Render a single due date that carries no explicit amount or percent as 100% of the payable total, keeping documents rendered after invopop/gobl#951 (which makes `pay.DueDate` amounts optional) looking exactly as they do today.

Changes:
- New `displayDueDates(terms, totals)` helper applies the assumption at render time only; explicit amounts and percents, and multi-due-date lists, render untouched
- `paymentTerms`/`paymentDueDates` now take `(terms, totals)` so invoices and orders share the behavior

Notes:
- Still pins gobl v0.504.0; when bumping past invopop/gobl#951, `dd.Amount` becomes `*num.Amount` and `displayDueDates` plus the `t.LM(dd.Amount)` call need nil handling.

Generated with Claude Code — https://claude.ai/code/ecc6fcbb-f34f-4ab9-bc09-90ec8cc9c4ae